### PR TITLE
Installing linuxbrew with install script to speed up linux bottle building process.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -21,11 +21,9 @@ for:
         - image: Ubuntu1804
 
     before_build:
-      # Following alternate install steps for linuxbrew from here: https://docs.brew.sh/Homebrew-on-Linux#alternative-installation
-      - git clone https://github.com/Homebrew/brew ~/.linuxbrew/Homebrew
-      - mkdir ~/.linuxbrew/bin
-      - ln -s ~/.linuxbrew/Homebrew/bin/brew ~/.linuxbrew/bin
-      - eval $(~/.linuxbrew/bin/brew shellenv)
+      # Installing linuxbrew and putting it in path.
+      - export PATH=$PATH:/home/linuxbrew/.linuxbrew/bin
+      - sh -c "$(curl -fsSL https://raw.githubusercontent.com/Linuxbrew/install/master/install.sh)"
   -
     matrix:
       only:


### PR DESCRIPTION
This change improves bottle building time on appveyor from 10+ mins to 3 mins. Please check [sample project](https://ci.appveyor.com/project/c2tarun/homebrew-tap) for build time.

*Issue #, if available:*

*Description of changes:*
We were using Linuxbrew's alternative install method, which was compiling all the dependencies for linuxbrew. This was taking lot of time and our bottle building for linux was taking around 10 mins. This changes replaces alternative install method with install script supported by linux brew.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
