### PR TITLE
Revert "chore: version bump to 0.49.0"

### DIFF
--- a/bottle-config.json
+++ b/bottle-config.json
@@ -1,7 +1,7 @@
 {
-    "version": "0.49.0",
-    "url": "https://api.github.com/repos/awslabs/aws-sam-cli/tarball/v0.49.0",
-    "sha256": "f177bc4fc22e1fec4940b0dc87c1e7fce365338a8f3e16133cc1dffaffd775c1",
+    "version": "0.48.0",
+    "url": "https://api.github.com/repos/awslabs/aws-sam-cli/tarball/v0.48.0",
+    "sha256": "a8613f3e41054e8a95a3d72eac395ce789e8acec52cea2ef0a179e64e4fd6d64",
     "bottle": {
         "root_url": "https://github.com/awslabs/aws-sam-cli/releases/download/v0.48.0/",
         "sha256": {


### PR DESCRIPTION
This reverts commit 48d1ebfc554e5ce269cfd4392d6c68a6c2ea6e07.

*Issue #, if available:*
Reverting as we are dealing with build issues.

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
