### PR TITLE
Add aws-sam-cli-rc Formula

### DIFF
--- a/ConfigProvider/config_provider.rb
+++ b/ConfigProvider/config_provider.rb
@@ -6,6 +6,7 @@ class ConfigProvider
     # We are moving values to json file so that it is easy to modify them by bot
 
     CONFIG_FILE = File.join(File.dirname(__FILE__), "..", "bottle-config.json")
+
     def initialize(config_file_path=CONFIG_FILE)
         file = File.read(config_file_path)
         @config_data = JSON.parse(file)

--- a/Formula/aws-sam-cli-rc.rb
+++ b/Formula/aws-sam-cli-rc.rb
@@ -4,15 +4,17 @@ require_relative '../ConfigProvider/config_provider'
 class AwsSamCli < Formula
   include Language::Python::Virtualenv
 
-  config_provider = ConfigProvider.new
+  config_provider = ConfigProvider.new(
+    File.join(File.dirname(__FILE__), "..", "bottle-config-rc.json")
+  )
 
   desc "AWS SAM CLI 🐿 is a tool for local development and testing of Serverless applications"
   homepage "https://github.com/awslabs/aws-sam-cli/"
   url config_provider.url()
   sha256 config_provider.sha256
-  head "https://github.com/awslabs/aws-sam-cli.git", :branch => "develop"
+  head "https://github.com/awslabs/aws-sam-cli.git", :branch => "release-v1.0.0"
 
-  conflicts_with 'aws-sam-cli-rc', :because => "both install the 'sam' binary"
+  conflicts_with 'aws-sam-cli', :because => "both install the 'sam' binary"
 
   bottle do
     root_url config_provider.root_url()
@@ -26,7 +28,7 @@ class AwsSamCli < Formula
   def install
     venv = virtualenv_create(libexec, "python3")
     system libexec/"bin/pip", "install", "pip==19.2.3"
-    system libexec/"bin/pip", "install", "-v", "--ignore-installed", buildpath
+    system libexec/"bin/pip", "install", "-v", "--pre", "--ignore-installed", buildpath
     system libexec/"bin/pip", "uninstall", "-y", "aws-sam-cli"
     venv.pip_install_and_link buildpath
   end

--- a/bottle-config-rc.json
+++ b/bottle-config-rc.json
@@ -1,0 +1,12 @@
+{
+    "version": "0.53.0",
+    "url": "https://api.github.com/repos/awslabs/aws-sam-cli/tarball/v0.53.0",
+    "sha256": "93e4929f778496e591fe2da2de0c87a3aaae842f68fd826bd092932aae464b78",
+    "bottle": {
+        "root_url": "https://github.com/awslabs/aws-sam-cli/releases/download/v0.53.0/",
+        "sha256": {
+            "sierra": "19311dd840b6d777637b37e8c508df4da0349b0ffeb6443c3d2ec443c3b8ecb2",
+            "linux": "30182b89f705c8e3702857e49195a02cdbf6007942a5721ea6406a8ab5d420d6"
+        }
+    }
+}


### PR DESCRIPTION
This seems to cover our bases with config providers and bottle builders. The config files align for now but for the rc1 release they should diverge.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
