### PR TITLE
fix: Correct class name on aws sam cli rc formula

### DIFF
--- a/Formula/aws-sam-cli-rc.rb
+++ b/Formula/aws-sam-cli-rc.rb
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 require_relative '../ConfigProvider/config_provider'
 
-class AwsSamCli < Formula
+class AwsSamCliRc < Formula
   include Language::Python::Virtualenv
 
   config_provider = ConfigProvider.new(


### PR DESCRIPTION
Error below

```
==> Tapping aws/tap
Cloning into '/usr/local/Homebrew/Library/Taps/aws/homebrew-tap'...
remote: Enumerating objects: 57, done.
remote: Counting objects: 100% (57/57), done.
remote: Compressing objects: 100% (45/45), done.
remote: Total 455 (delta 31), reused 21 (delta 11), pack-reused 398
Receiving objects: 100% (455/455), 92.56 KiB | 3.19 MiB/s, done.
Resolving deltas: 100% (186/186), done.
Error: Invalid formula: /usr/local/Homebrew/Library/Taps/aws/homebrew-tap/Formula/aws-sam-cli-rc.rb
No available formula with the name "aws-sam-cli-rc"
In formula file: /usr/local/Homebrew/Library/Taps/aws/homebrew-tap/Formula/aws-sam-cli-rc.rb
Expected to find class AwsSamCliRc, but only found: AwsSamCli.
Error: Cannot tap aws/tap: invalid syntax in tap!
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
