### PR TITLE
set GOPROXY to direct

### DIFF
--- a/Formula/ec2-instance-selector.rb
+++ b/Formula/ec2-instance-selector.rb
@@ -18,7 +18,7 @@ class Ec2InstanceSelector < Formula
   depends_on "go" => :build
 
   def install
-    system "VERSION=v#{$config_provider.version} make compile"
+    system "GOPROXY=direct VERSION=v#{$config_provider.version} make compile"
     bin.install "build/ec2-instance-selector"
   end
 

--- a/Formula/ec2-metadata-mock.rb
+++ b/Formula/ec2-metadata-mock.rb
@@ -18,7 +18,7 @@ class Ec2MetadataMock < Formula
   depends_on "go" => :build
 
   def install
-    system "VERSION=v#{$config_provider.version} make compile"
+    system "GOPROXY=direct VERSION=v#{$config_provider.version} make compile"
     bin.install "build/ec2-metadata-mock"
   end
 


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Use GOPROXY=direct on go builds so that the google module proxy is not required. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
