### PR TITLE
Add AWS Copilot Formula 🍾

### DIFF
--- a/Formula/copilot-cli.rb
+++ b/Formula/copilot-cli.rb
@@ -1,0 +1,35 @@
+# -*- coding: utf-8 -*-
+require_relative '../ConfigProvider/config_provider'
+
+class CopilotCli < Formula
+    $config_provider = ConfigProvider.new('copilot-cli')
+
+    desc "Copilot CLI - build, release and operate your container apps on AWS"
+    homepage "https://aws.github.io/copilot-cli/"
+    version $config_provider.version
+    bottle :unneeded
+
+    if OS.mac?
+      url "#{$config_provider.root_url}macOS_amd64.tar.gz"
+      sha256 $config_provider.sierra_hash
+    elsif OS.linux?
+      if Hardware::CPU.intel?
+        url "#{$config_provider.root_url}linux_amd64.tar.gz"
+        sha256 $config_provider.linux_hash
+      end
+    end
+
+    def install
+      bin.install $config_provider.bin
+
+      # Install bash completion
+      (bash_completion/$config_provider.bin).write `#{bin}/#{$config_provider.bin} completion bash`
+
+      # Install zsh completion
+      (zsh_completion/$config_provider.bin).write `#{bin}/#{$config_provider.bin} completion zsh`
+    end
+
+    test do
+        assert_match "Getting Started", shell_output("#{bin}/#{$config_provider.bin} --help")
+    end
+  end

--- a/README.md
+++ b/README.md
@@ -15,8 +15,9 @@ brew install <FORMULA>
 | Repository | Formula |
 | ---------- | ------- |
 | [aws-sam-cli](https://github.com/awslabs/aws-sam-cli) | [formula](Formula/aws-sam-cli.rb) |
-| [ec2-instance-selector](https://github.com/aws/amazon-ec2-instance-selector) | [formula](Formula/ec2-instance-selector) |
-| [ec2-metadata-mock](https://github.com/aws/amazon-ec2-metadata-mock) | [formula](Formula/ec2-metadata-mock) |
+| [copilot-cli](https://github.com/aws/copilot-cli) | [formula](Formula/copilot-cli.rb) |
+| [ec2-instance-selector](https://github.com/aws/amazon-ec2-instance-selector) | [formula](Formula/ec2-instance-selector.rb) |
+| [ec2-metadata-mock](https://github.com/aws/amazon-ec2-metadata-mock) | [formula](Formula/ec2-metadata-mock.rb) |
 
 
 ## Documentation

--- a/bottle-configs/copilot-cli.json
+++ b/bottle-configs/copilot-cli.json
@@ -1,0 +1,13 @@
+{
+
+    "version": "0.1.0",
+    "name": "copilot-cli",
+    "bin": "copilot",
+    "bottle": {
+        "root_url": "https://github.com/aws/copilot-cli/releases/download/v0.1.0/copilot_0.1.0_",
+        "sha256": {
+            "sierra": "7e7844ef3f25e37cce671a8a4af03135b8f8488cda934c7076d2f3031a8d0a13",
+            "linux": "30182b89f705c8e3702857e49195a02cdbf6007942a5721ea6406a8ab5d420d6"
+        }
+    }
+}


### PR DESCRIPTION
Copilot is a new CLI from the ECS Developer Experience team
to make developing, releasing and operating container apps on
AWS delightful.

This PR is to add Copilot to the AWS tap. Since our CLI is vended
as static binaries, we can skip the build step and use our pre-built
binaries which are produced as part of our release pipeline.

Right now we have binaries for MacOS and Intel Linux (ARM to come).

We also install shell autocompletion when installed from the tap.

Thanks so much for hosting this tap!

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
