### PR TITLE
Switch python version to be python3.7 for sam cli formulas

### DIFF
--- a/Formula/aws-sam-cli-rc.rb
+++ b/Formula/aws-sam-cli-rc.rb
@@ -21,7 +21,7 @@ class AwsSamCliRc < Formula
     sha256 config_provider.linux_hash() => :x86_64_linux
   end
 
-  depends_on "python"
+  depends_on "python@3.7"
 
   def install
     venv = virtualenv_create(libexec, "python3")

--- a/Formula/aws-sam-cli.rb
+++ b/Formula/aws-sam-cli.rb
@@ -21,7 +21,7 @@ class AwsSamCli < Formula
     sha256 config_provider.linux_hash() => :x86_64_linux
   end
 
-  depends_on "python"
+  depends_on "python@3.7"
 
   def install
     venv = virtualenv_create(libexec, "python3")


### PR DESCRIPTION
Explicitly reference python3.7 as dependent version


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
