### PR TITLE
ec2-instance-selector: static bottles

### DIFF
--- a/ConfigProvider/config_provider.rb
+++ b/ConfigProvider/config_provider.rb
@@ -49,4 +49,8 @@ class ConfigProvider
     def linux_hash
         @config_data['bottle']['sha256']['linux']
     end
+
+    def linux_arm_hash
+        @config_data['bottle']['sha256']['linux_arm']
+    end
 end

--- a/Formula/ec2-instance-selector.rb
+++ b/Formula/ec2-instance-selector.rb
@@ -7,19 +7,24 @@ class Ec2InstanceSelector < Formula
 
   desc "EC2 Instance Selector is a tool filter EC2 instance types based on resource criteria"
   homepage "https://github.com/aws/amazon-ec2-instance-selector/"
-  url $config_provider.url()
-  sha256 $config_provider.sha256
-  head "https://github.com/aws/amazon-ec2-instance-selector.git", :branch => "master"
-  bottle do
-    root_url $config_provider.root_url()
-    cellar :any_skip_relocation
+  version $config_provider.version
+  bottle :unneeded
+
+  if OS.mac?
+    url "#{$config_provider.root_url}-darwin-amd64.tar.gz"
+    sha256 $config_provider.sierra_hash
+  elsif OS.linux?
+    if Hardware::CPU.intel?
+      url "#{$config_provider.root_url}-linux-amd64.tar.gz"
+      sha256 $config_provider.linux_hash
+    elsif Hardware::CPU.arm?
+      url "#{$config_provider.root_url}-linux-arm64.tar.gz"
+      sha256 $config_provider.linux_arm_hash
+    end
   end
 
-  depends_on "go" => :build
-
   def install
-    system "GOPROXY=direct VERSION=v#{$config_provider.version} make compile"
-    bin.install "build/ec2-instance-selector"
+    bin.install $config_provider.bin
   end
 
   test do

--- a/bottle-configs/ec2-instance-selector.json
+++ b/bottle-configs/ec2-instance-selector.json
@@ -1,14 +1,13 @@
 {
     "name": "ec2-instance-selector",
-    "version": "1.3.0",
+    "version": "1.3.1",
     "bin": "ec2-instance-selector",
-    "url": "https://api.github.com/repos/aws/amazon-ec2-instance-selector/tarball/v1.3.0",
-    "sha256": "a90d94745f7466d660253a411639ab1d0d9eb3f023306da94b09196f20c835c0",
     "bottle": {
-        "root_url": "https://github.com/aws/amazon-ec2-instance-selector/releases/download/v1.3.0/",
+        "root_url": "https://github.com/aws/amazon-ec2-instance-selector/releases/download/v1.3.1/ec2-instance-selector",
         "sha256": {
-            "sierra": "",
-            "linux": ""
+            "sierra": "5ec5e53cbbf33844bb4742d40f520810d34d3c4e868441a3d7ab7035fc0dc346",
+            "linux": "3db9a28d2e57b1ef062be736f02a858e71d83de7bcb615957b11afd4a2d99b0d",
+            "linux_arm": "2876a918d648bc872b194bee20506bec7a974dcb3b53b12958fb34eb816cc878"
         }
     }
 }

--- a/build-formula.sh
+++ b/build-formula.sh
@@ -5,8 +5,9 @@ set -euo pipefail
 # This allows it to be executed from anywhere on the file system.
 SCRIPTPATH="$( cd "$(dirname "$0")" ; pwd -P )"
 BUILD_DIR="$SCRIPTPATH/build"
+RESULTS_DIR="$BUILD_DIR/results"
 # Create temp dir at root to hold files during this execution
-mkdir -p $BUILD_DIR
+mkdir -p $BUILD_DIR $RESULTS_DIR
 
 export HOMEBREW_NO_INSTALL_CLEANUP=1
 # Commenting out the auto upgrade since appveyor mac has an old version and fails buildilng bottles for SAM CLI
@@ -90,9 +91,9 @@ function fail_msg() {
     exit 2
 }
 
-trap fail_msg err int term kill
+trap fail_msg err int term
 
-brew untap ${SAVED_TAPS[@]} 2>/dev/null || :
+brew untap "${SAVED_TAPS[@]}" 2>/dev/null || :
 
 if [[ ${USER_TAP} != "" ]]; then
   TAP="${USER_TAP}"
@@ -149,9 +150,6 @@ if [[ $(grep -c 'bottle :unneeded' "${FORMULA_FILE}") -eq 0 ]]; then
   brew uninstall -f ${BOTTLE}
   echo "[${BOTTLE}]: Installing release file"
   brew install ${RELEASE_FILE}
-else 
-  ## Touch a fake bottle so that build summary is accurate
-  touch "${BUILD_DIR}/${BOTTLE}.bottle.tar.gz"
 fi
 
 BUILT_BOTTLE_VERSION="$(${BIN_NAME} --version | grep -Eo '[0-9]+\.[0-9]+\.[0-9a-zA-Z]+')"
@@ -161,6 +159,8 @@ if [[ "${BOTTLE_ASSET_VERSION}" != "${BUILT_BOTTLE_VERSION}" ]]; then
 fi
 
 echo "✅ [${BOTTLE}]: Verified that the new ${BOTTLE} version ${BUILT_BOTTLE_VERSION} is the same as what is expected ${BOTTLE_ASSET_VERSION} 🎉🥂✅"
+## Touch results file for build-bottles summary
+touch "${RESULTS_DIR}/${BOTTLE}"
 
 brew uninstall -f ${BOTTLE}
 


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
 - Move to use static bottles vended from the ec2-instance-selector github releases.
 - Modified `build-formula` to skip bottle building when `bottle :unneeded` is specified in the formula.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
