### PR TITLE
xray daemon

### DIFF
--- a/Formula/xray-daemon.rb
+++ b/Formula/xray-daemon.rb
@@ -1,0 +1,38 @@
+# -*- coding: utf-8 -*-
+require_relative '../ConfigProvider/config_provider'
+
+class XrayDaemon < Formula
+
+  $config_provider = ConfigProvider.new('xray-daemon')
+
+  desc "The AWS X-Ray daemon listens for traffic on UDP port 2000, gathers raw segment data, and relays it to the AWS X-Ray API."
+  homepage "https://github.com/aws/aws-xray-daemon/"
+  version $config_provider.version
+  bottle :unneeded
+
+  if OS.mac?
+    url "#{$config_provider.root_url}/aws-xray-daemon-macos-#{$config_provider.version}.zip"
+    sha256 $config_provider.sierra_hash
+  elsif OS.linux?
+    if Hardware::CPU.intel?
+      url "#{$config_provider.root_url}/aws-xray-daemon-linux-#{$config_provider.version}.zip"
+      sha256 $config_provider.linux_hash
+    elsif Hardware::CPU.arm?
+      url "#{$config_provider.root_url}/aws-xray-daemon-linux-arm64-#{$config_provider.version}.zip"
+      sha256 $config_provider.linux_arm_hash
+    end
+  end
+
+  def install
+    if OS.mac?
+      bin.install "#{$config_provider.bin}_mac"
+      mv bin/"xray_mac", bin/"xray"
+    else
+      bin.install $config_provider.bin
+    end
+  end
+
+  test do
+    assert_match "Usage", shell_output("#{bin}/#{$config_provider.bin} --help")
+  end
+end

--- a/Formula/xray-daemon.rb
+++ b/Formula/xray-daemon.rb
@@ -17,18 +17,16 @@ class XrayDaemon < Formula
     if Hardware::CPU.intel?
       url "#{$config_provider.root_url}/aws-xray-daemon-linux-#{$config_provider.version}.zip"
       sha256 $config_provider.linux_hash
-    elsif Hardware::CPU.arm?
-      url "#{$config_provider.root_url}/aws-xray-daemon-linux-arm64-#{$config_provider.version}.zip"
-      sha256 $config_provider.linux_arm_hash
     end
   end
 
   def install
     if OS.mac?
-      bin.install "#{$config_provider.bin}_mac"
-      mv bin/"xray_mac", bin/"xray"
+      bin.install "xray_mac"
+      mv bin/"xray_mac", bin/"#{$config_provider.bin}"
     else
-      bin.install $config_provider.bin
+      bin.install "xray"
+      mv bin/"xray", bin/"#{$config_provider.bin}"
     end
   end
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ brew install <FORMULA>
 | [copilot-cli](https://github.com/aws/copilot-cli) | [formula](Formula/copilot-cli.rb) |
 | [ec2-instance-selector](https://github.com/aws/amazon-ec2-instance-selector) | [formula](Formula/ec2-instance-selector.rb) |
 | [ec2-metadata-mock](https://github.com/aws/amazon-ec2-metadata-mock) | [formula](Formula/ec2-metadata-mock.rb) |
-
+| [xray-daemon](https://github.com/aws/aws-xray-daemon) | [formula](Formula/xray-daemon.rb) |
 
 ## Documentation
 

--- a/bottle-configs/xray-daemon.json
+++ b/bottle-configs/xray-daemon.json
@@ -1,0 +1,13 @@
+{
+    "name": "xray-daemon",
+    "version": "3.2.0",
+    "bin": "xray",
+    "bottle": {
+        "root_url": "https://s3.us-east-2.amazonaws.com/aws-xray-assets.us-east-2/xray-daemon",
+        "sha256": {
+            "sierra": "22a2b0a8ec9bf0c8d3ea1aaea0ad4951bf5b125782165180b0389c36d1246e4f",
+            "linux": "5563498bd5c6dd08556827bc87aec269f0655349fe1079caf2d21d0049fc90ca",
+            "linux_arm": ""
+        }
+    }
+}

--- a/bottle-configs/xray-daemon.json
+++ b/bottle-configs/xray-daemon.json
@@ -1,7 +1,7 @@
 {
     "name": "xray-daemon",
     "version": "3.2.0",
-    "bin": "xray",
+    "bin": "xray-daemon",
     "bottle": {
         "root_url": "https://s3.us-east-2.amazonaws.com/aws-xray-assets.us-east-2/xray-daemon",
         "sha256": {


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/homebrew-tap/issues/83
https://github.com/aws/aws-xray-daemon/issues/57

*Description of changes:*
- Add formula for the aws-xray-daemon

Tested on forked tap:
```
$ brew tap bwagner5/tap
$ brew install bwagner5/tap/xray-daemon
$ xray-daemon --help
Usage: X-Ray [options]
	-a	--resource-arn	Amazon Resource Name (ARN) of the AWS resource running the daemon.
	-o	--local-mode	Don't check for EC2 instance metadata.
	-m	--buffer-memory	Change the amount of memory in MB that buffers can use (minimum 3).
	-n	--region	Send segments to X-Ray service in a specific region.
	-b	--bind		Overrides default UDP address (127.0.0.1:2000).
	-t	--bind-tcp	Overrides default TCP address (127.0.0.1:2000).
	-r	--role-arn	Assume the specified IAM role to upload segments to a different account.
	-c	--config	Load a configuration file from the specified path.
	-f	--log-file	Output logs to the specified file path.
	-l	--log-level	Log level, from most verbose to least: dev, debug, info, warn, error, prod (default).
	-p	--proxy-address	Proxy address through which to upload segments.
	-v	--version	Show AWS X-Ray daemon version.
	-h	--help		Show this screen
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
