### PR TITLE
Building only sam-cli when building on appveyor.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -34,7 +34,7 @@ for:
 
 # Building bottles shell script.
 build_script:
-  - ./build-bottles.sh
+  - ./build-formula.sh -f Formula/aws-sam-cli.rb
 
 artifacts:
   - path: "build/*.bottle.tar.gz"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Building only aws-sam-cli when using SAM's appveyor build.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
