### PR TITLE
Add aws-simple-ec2-cli formula

### DIFF
--- a/Formula/aws-simple-ec2-cli.rb
+++ b/Formula/aws-simple-ec2-cli.rb
@@ -1,0 +1,33 @@
+# -*- coding: utf-8 -*-
+require_relative '../ConfigProvider/config_provider'
+
+class AwsSimpleEc2Cli < Formula
+
+  $config_provider = ConfigProvider.new('aws-simple-ec2-cli')
+
+  desc "AWS Simple EC2 CLI is a tool that simplifies the process of launching, connecting and terminating EC2 instances."
+  homepage "https://github.com/awslabs/aws-simple-ec2-cli/"
+  version $config_provider.version
+  bottle :unneeded
+
+  if OS.mac?
+    url "#{$config_provider.root_url}-darwin-amd64.tar.gz"
+    sha256 $config_provider.sierra_hash
+  elsif OS.linux?
+    if Hardware::CPU.intel?
+      url "#{$config_provider.root_url}-linux-amd64.tar.gz"
+      sha256 $config_provider.linux_hash
+    elsif Hardware::CPU.arm?
+      url "#{$config_provider.root_url}-linux-arm64.tar.gz"
+      sha256 $config_provider.linux_arm_hash
+    end
+  end
+
+  def install
+    bin.install $config_provider.bin
+  end
+
+  test do
+    assert_match "Usage", shell_output("#{bin}/aws-simple-ec2-cli --help")
+  end
+end

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ brew install <FORMULA>
 | Repository | Formula |
 | ---------- | ------- |
 | [aws-sam-cli](https://github.com/awslabs/aws-sam-cli) | [formula](Formula/aws-sam-cli.rb) |
+| [aws-simple-ec2-cli](https://github.com/awslabs/aws-simple-ec2-cli) | [formula](Formula/aws-simple-ec2-cli.rb) |
 | [copilot-cli](https://github.com/aws/copilot-cli) | [formula](Formula/copilot-cli.rb) |
 | [ec2-instance-selector](https://github.com/aws/amazon-ec2-instance-selector) | [formula](Formula/ec2-instance-selector.rb) |
 | [ec2-metadata-mock](https://github.com/aws/amazon-ec2-metadata-mock) | [formula](Formula/ec2-metadata-mock.rb) |

--- a/bottle-configs/aws-simple-ec2-cli.json
+++ b/bottle-configs/aws-simple-ec2-cli.json
@@ -1,0 +1,13 @@
+{
+    "name": "aws-simple-ec2-cli",
+    "version": "0.5.1",
+    "bin": "aws-simple-ec2-cli",
+    "bottle": {
+        "root_url": "https://github.com/awslabs/aws-simple-ec2-cli/releases/download/v0.5.1/aws-simple-ec2-cli",
+        "sha256": {
+            "sierra": "37795e65c4693c833dc7a9ec78c124a70998e8b3b007088272fc55bad598b4fa",
+            "linux": "d31b0ea8e165e8f820458630d33fa6f74677c4526a1c00a784700686d95d2248",
+            "linux_arm": "dc4efa9f2e6a77cc4ac6d4a7f663b6ff36cedaf29f0be135c5154a07d31eb9b5"
+        }
+    }
+}


### PR DESCRIPTION
*Description of changes:*
Add the awslabs/aws-simple-ec2-cli tool. [aws-simple-ec2-cli](https://github.com/awslabs/aws-simple-ec2-cli) provides customers with a simplified cli experience to make getting started with ec2 easier. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
