### PR TITLE
Add a meta formula for "container tools"

### DIFF
--- a/Formula/container-tools.rb
+++ b/Formula/container-tools.rb
@@ -14,7 +14,7 @@ class ContainerTools < Formula
     depends_on "docker-credential-helper-ecr"
 
     def install
-        (bin+"awscontainertools").write <<-EOS.undent
+        (bin+"awscontainertools").write <<-EOS
             #!/bin/sh
 
             echo "AWS Container Tools installed"

--- a/Formula/container-tools.rb
+++ b/Formula/container-tools.rb
@@ -14,7 +14,7 @@ class ContainerTools < Formula
     depends_on "docker-credential-helper-ecr"
 
     def install
-        (bin+"awscontainertools").write <<-EOS.endent
+        (bin+"awscontainertools").write <<-EOS.undent
             #!/bin/sh
 
             echo "AWS Container Tools installed"

--- a/Formula/container-tools.rb
+++ b/Formula/container-tools.rb
@@ -1,4 +1,4 @@
-class AwsContainerTools < Formula
+class ContainerTools < Formula
     desc "Meta Package for common AWS Container tools"
     url "file:///dev/null"
     sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"

--- a/Formula/container-tools.rb
+++ b/Formula/container-tools.rb
@@ -1,5 +1,7 @@
 class ContainerTools < Formula
     desc "Meta Package for common AWS Container tools"
+    version 1.0.0
+    homepage "https://github.com/aws/"
     url "file:///dev/null"
     sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
 

--- a/Formula/container-tools.rb
+++ b/Formula/container-tools.rb
@@ -1,7 +1,8 @@
 class ContainerTools < Formula
     desc "Meta Package for common AWS Container tools"
-    version 1.0.0
+    version "1.0.0"
     homepage "https://github.com/aws/"
+    bottle :unneeded
     url "file:///dev/null"
     sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
 

--- a/Formula/container-tools.rb
+++ b/Formula/container-tools.rb
@@ -1,0 +1,20 @@
+class AwsContainerTools < Formula
+    desc "Meta Package for common AWS Container tools"
+    url "file:///dev/null"
+    sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+
+    depends_on "awscli"
+    depends_on "eksctl"
+    depends_on "kubernetes-cli"
+    depends_on "aws/tap/copilot-cli"
+    depends_on "aws-iam-authenticator"
+    depends_on "docker-credential-helper-ecr"
+
+    def install
+        (bin+"awscontainertools").write <<-EOS.endent
+            #!/bin/sh
+
+            echo "AWS Container Tools installed"
+        EOS
+    end
+end

--- a/README.md
+++ b/README.md
@@ -12,13 +12,14 @@ brew install <FORMULA>
 
 ## Formulae
 
-| Repository | Formula |
-| ---------- | ------- |
-| [aws-sam-cli](https://github.com/awslabs/aws-sam-cli) | [formula](Formula/aws-sam-cli.rb) |
-| [copilot-cli](https://github.com/aws/copilot-cli) | [formula](Formula/copilot-cli.rb) |
-| [ec2-instance-selector](https://github.com/aws/amazon-ec2-instance-selector) | [formula](Formula/ec2-instance-selector.rb) |
-| [ec2-metadata-mock](https://github.com/aws/amazon-ec2-metadata-mock) | [formula](Formula/ec2-metadata-mock.rb) |
-| [xray-daemon](https://github.com/aws/aws-xray-daemon) | [formula](Formula/xray-daemon.rb) |
+| Repository | Formula | Description |
+| ---------- | ------- | ----------- |
+| [aws-sam-cli](https://github.com/awslabs/aws-sam-cli) | [formula](Formula/aws-sam-cli.rb) | CLI tool to build, test, debug, and deploy Serverless applications using AWS Lambda |
+| container-tools | [formula](Formula/container-tools.rb) | Meta-package to install common container tools |
+| [copilot-cli](https://github.com/aws/copilot-cli) | [formula](Formula/copilot-cli.rb) | Build, release and operate production ready containerized applications on Amazon ECS |
+| [ec2-instance-selector](https://github.com/aws/amazon-ec2-instance-selector) | [formula](Formula/ec2-instance-selector.rb) | CLI tool and go library which recommends instance types based on resource criteria like vcpus and memory |
+| [ec2-metadata-mock](https://github.com/aws/amazon-ec2-metadata-mock) | [formula](Formula/ec2-metadata-mock.rb) | A tool to simulate Amazon EC2 instance metadata |
+| [xray-daemon](https://github.com/aws/aws-xray-daemon) | [formula](Formula/xray-daemon.rb) | Relays traffic to AWS X-Ray API |
 
 ## Documentation
 


### PR DESCRIPTION
*Description of changes:*

Adds a new formula for common AWS container tools in 1 package

`brew install aws/tap/container-tools` will install (if not already installed)

- awscli
- kubectl
- copilot
- docker ecr helper (used for docker push/pull)
- aws iam authenticator (used for kubectl auth)

Also added a description to the readme for users to get a quick glance at formula without clicking out to external repos