### PR TITLE
Update build-formula.sh

### DIFF
--- a/build-formula.sh
+++ b/build-formula.sh
@@ -120,7 +120,7 @@ echo "🎬 Starting formula build for ${FORMULA_FILE}"
 brew uninstall -f ${BOTTLE}
 
 ## Build formula from source locally
-brew install --build-from-source "${SCRIPTPATH}/${FORMULA_FILE}" #"${TAP}/${BOTTLE}"
+brew install --build-from-source "${SCRIPTPATH}/${FORMULA_FILE}"
 brew uninstall -f ${BOTTLE}
 ## Build bottle
 brew install --build-bottle ${TAP}/${BOTTLE}

--- a/build-formula.sh
+++ b/build-formula.sh
@@ -120,7 +120,7 @@ echo "🎬 Starting formula build for ${FORMULA_FILE}"
 brew uninstall -f ${BOTTLE}
 
 ## Build formula from source locally
-brew install --build-from-source "${SCRIPTPATH}/${FORMULA_FILE}" "${TAP}/${BOTTLE}"
+brew install --build-from-source "${SCRIPTPATH}/${FORMULA_FILE}" #"${TAP}/${BOTTLE}"
 brew uninstall -f ${BOTTLE}
 ## Build bottle
 brew install --build-bottle ${TAP}/${BOTTLE}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Following line start to build and install bottle twice since homebrew v2.5.3 (the latest successful run was homebrew v2.5.2), which fails since the bottle is already installed with --build-from-source;
`brew install --build-from-source "${SCRIPTPATH}/${FORMULA_FILE}" "${TAP}/${BOTTLE}"`

Removing `"${TAP}/${BOTTLE}"` at the end of the command fixes the issue, as it only installs the bottle once, and passes this step.
 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
