### PR TITLE
correct root_url for v1.16.0

### DIFF
--- a/bottle-configs/aws-sam-cli.json
+++ b/bottle-configs/aws-sam-cli.json
@@ -5,7 +5,7 @@
     "name": "aws-sam-cli",
     "bin": "sam",
     "bottle": {
-        "root_url": "https://github.com/aws/aws-sam-cli/releases/download/v1.15.0/",
+        "root_url": "https://github.com/aws/aws-sam-cli/releases/download/v1.16.0/",
         "sha256": {
             "sierra": "e02edd6d4c57bd76ff6bc8df799f0e2d838c2ba05ddd607d0fc8416ce4bfcc8b",
             "linux": "cb8085e29945b0f53c805d3848cb3bb4ef70f06b4c6cfaef50dd7da7968b9329"

--- a/bottle-configs/aws-sam-cli.json
+++ b/bottle-configs/aws-sam-cli.json
@@ -7,7 +7,7 @@
     "bottle": {
         "root_url": "https://github.com/aws/aws-sam-cli/releases/download/v1.16.0/",
         "sha256": {
-            "sierra": "e02edd6d4c57bd76ff6bc8df799f0e2d838c2ba05ddd607d0fc8416ce4bfcc8b",
+            "sierra": "6db6119f60a141c42ada94733851010142e4a7fdfea68b898f48ffcabb85bb42",
             "linux": "cb8085e29945b0f53c805d3848cb3bb4ef70f06b4c6cfaef50dd7da7968b9329"
         }
     }


### PR DESCRIPTION

*Description of changes:*

The download url is broken when updating aws-sam-cli to 1.16.0

```
==> Upgrading aws/tap/aws-sam-cli 1.15.0 -> 1.16.0
==> Downloading https://github.com/aws/aws-sam-cli/releases/download/v1.15.0//aws-sam-cli-1.16.0.sierra
-=O#- #  #    #
curl: (22) The requested URL returned error: 404
Error: Failed to download resource "aws-sam-cli"
Download failed: https://github.com/aws/aws-sam-cli/releases/download/v1.15.0//aws-sam-cli-1.16.0.sierra.bottle.tar.gz
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
