### PR TITLE
Include QLDB Shell as an installable formula

### DIFF
--- a/Formula/qldbshell.rb
+++ b/Formula/qldbshell.rb
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+require_relative '../ConfigProvider/config_provider'
+
+class Qldbshell < Formula
+
+  $config_provider = ConfigProvider.new('qldbshell')
+
+  desc "A CLI for interacting with QLDB ledgers"
+  homepage "https://github.com/awslabs/amazon-qldb-shell"
+  version $config_provider.version
+  bottle :unneeded
+
+  if OS.mac?
+    url "#{$config_provider.root_url}v#{$config_provider.version}/#{$config_provider.bin}-mac.tar.gz"
+    sha256 $config_provider.sierra_hash
+  end
+
+  def install
+    bin.install $config_provider.bin
+  end
+end

--- a/bottle-configs/qldbshell.json
+++ b/bottle-configs/qldbshell.json
@@ -1,0 +1,11 @@
+{
+  "name": "qldbshell",
+  "version": "2.0.0.alpha1",
+  "bin": "qldbshell",
+  "bottle": {
+    "root_url": "https://github.com/awslabs/amazon-qldb-shell/releases/download/",
+    "sha256": {
+      "sierra": "2d699b68d7f98182450313b820b79dfc1f7e31cd875bfc746c0a8f56d020a3fe"
+    }
+  }
+}


### PR DESCRIPTION
QLDB Shell is a CLI utility for communicating with the AWS Quantum Ledger Database. It operates much like the MySQL shell and can be used to run sample queries from the command line for scripting or debugging. This PR adds qldbshell as a Homebrew formula for the AWS tap.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
