### PR TITLE
Run `brew style --fix` to update deprecated syntax

### DIFF
--- a/Formula/aws-sam-cli-nightly.rb
+++ b/Formula/aws-sam-cli-nightly.rb
@@ -1,22 +1,20 @@
-# -*- coding: utf-8 -*-
-require_relative '../ConfigProvider/config_provider'
+require_relative "../ConfigProvider/config_provider"
 
 class AwsSamCliNightly < Formula
   include Language::Python::Virtualenv
 
-  config_provider = ConfigProvider.new('aws-sam-cli-nightly')
+  config_provider = ConfigProvider.new("aws-sam-cli-nightly")
 
-  desc "AWS SAM CLI 🐿 is a tool for local development and testing of Serverless applications. This is a pre-release version of AWS SAM CLI."
+  desc "AWS SAM CLI 🐿 is a tool for local development and testing of Serverless applications. This is a pre-release version of AWS SAM CLI"
   homepage "https://github.com/aws/aws-sam-cli/"
-  url config_provider.url()
+  url config_provider.url
   sha256 config_provider.sha256
-  head "https://github.com/aws/aws-sam-cli.git", :branch => "nightly-builds"
+  head "https://github.com/aws/aws-sam-cli.git", branch: "nightly-builds"
 
   bottle do
-    root_url config_provider.root_url()
-    cellar :any_skip_relocation
-    sha256 config_provider.sierra_hash() => :sierra
-    sha256 config_provider.linux_hash() => :x86_64_linux
+    root_url config_provider.root_url
+    sha256 cellar: :any_skip_relocation, sierra:       config_provider.sierra_hash
+    sha256 cellar: :any_skip_relocation, x86_64_linux: config_provider.linux_hash
   end
 
   depends_on "python@3.8"
@@ -27,7 +25,7 @@ class AwsSamCliNightly < Formula
     system libexec/"bin/pip", "install", "-v", "--pre", "--ignore-installed", buildpath
     system libexec/"bin/pip", "uninstall", "-y", "aws-sam-cli"
     # bin folder is not created automatically
-    self.bin.mkpath
+    bin.mkpath
     venv.pip_install_and_link buildpath
   end
 

--- a/Formula/aws-sam-cli-rc.rb
+++ b/Formula/aws-sam-cli-rc.rb
@@ -1,27 +1,25 @@
-# -*- coding: utf-8 -*-
-require_relative '../ConfigProvider/config_provider'
+require_relative "../ConfigProvider/config_provider"
 
 class AwsSamCliRc < Formula
   include Language::Python::Virtualenv
 
-  config_provider = ConfigProvider.new('aws-sam-cli-rc')
+  config_provider = ConfigProvider.new("aws-sam-cli-rc")
 
   desc "AWS SAM CLI 🐿 is a tool for local development and testing of Serverless applications"
   homepage "https://github.com/awslabs/aws-sam-cli/"
-  url config_provider.url()
+  url config_provider.url
   sha256 config_provider.sha256
-  head "https://github.com/awslabs/aws-sam-cli.git", :branch => "release-v1.0.0"
-
-  conflicts_with 'aws-sam-cli', :because => "both install the 'sam' binary"
+  head "https://github.com/awslabs/aws-sam-cli.git", branch: "release-v1.0.0"
 
   bottle do
-    root_url config_provider.root_url()
-    cellar :any_skip_relocation
-    sha256 config_provider.sierra_hash() => :sierra
-    sha256 config_provider.linux_hash() => :x86_64_linux
+    root_url config_provider.root_url
+    sha256 cellar: :any_skip_relocation, sierra:       config_provider.sierra_hash
+    sha256 cellar: :any_skip_relocation, x86_64_linux: config_provider.linux_hash
   end
 
   depends_on "python@3.7"
+
+  conflicts_with "aws-sam-cli", because: "both install the 'sam' binary"
 
   def install
     venv = virtualenv_create(libexec, "python3.7")

--- a/Formula/aws-sam-cli.rb
+++ b/Formula/aws-sam-cli.rb
@@ -1,27 +1,25 @@
-# -*- coding: utf-8 -*-
-require_relative '../ConfigProvider/config_provider'
+require_relative "../ConfigProvider/config_provider"
 
 class AwsSamCli < Formula
   include Language::Python::Virtualenv
 
-  config_provider = ConfigProvider.new('aws-sam-cli')
+  config_provider = ConfigProvider.new("aws-sam-cli")
 
   desc "AWS SAM CLI 🐿 is a tool for local development and testing of Serverless applications"
   homepage "https://github.com/awslabs/aws-sam-cli/"
-  url config_provider.url()
+  url config_provider.url
   sha256 config_provider.sha256
-  head "https://github.com/awslabs/aws-sam-cli.git", :branch => "develop"
-
-  conflicts_with 'aws-sam-cli-rc', :because => "both install the 'sam' binary"
+  head "https://github.com/awslabs/aws-sam-cli.git", branch: "develop"
 
   bottle do
-    root_url config_provider.root_url()
-    cellar :any_skip_relocation
-    sha256 config_provider.sierra_hash() => :sierra
-    sha256 config_provider.linux_hash() => :x86_64_linux
+    root_url config_provider.root_url
+    sha256 cellar: :any_skip_relocation, sierra:       config_provider.sierra_hash
+    sha256 cellar: :any_skip_relocation, x86_64_linux: config_provider.linux_hash
   end
 
   depends_on "python@3.8"
+
+  conflicts_with "aws-sam-cli-rc", because: "both install the 'sam' binary"
 
   def install
     venv = virtualenv_create(libexec, "python3.8")


### PR DESCRIPTION
*Issue #, if available:*
Closes #187 

*Description of changes:*
Forked the repo and ran `brew style --fix Formula` from the root. There are a further 9 offences the tool did not auto-fix, but I was hesitant to make any further changes as it already altered more than I expected. The `bottle do` block is the important change, so if the other lint changes are not required I can alter this to just change that block. Running the command on my local tap removes the warnings, but I'm unfamiliar with the changes the tool made so this will probably need further testing.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
