### PR TITLE
apply fixes by `brew style --fix`

### DIFF
--- a/Formula/aws-sam-cli.rb
+++ b/Formula/aws-sam-cli.rb
@@ -6,7 +6,7 @@ class AwsSamCli < Formula
 
   config_provider = ConfigProvider.new('aws-sam-cli')
 
-  desc "AWS SAM CLI 🐿 is a tool for local development and testing of Serverless applications"
+  desc "aws-sam-cli 🐿 is a tool for local development and testing of Serverless apps"
   homepage "https://github.com/awslabs/aws-sam-cli/"
   url config_provider.url()
   sha256 config_provider.sha256


### PR DESCRIPTION
*Issue #, if available:* none

*Description of changes:*

```bash
brew style --fix aws-sam-cli
```

```txt
/home/linuxbrew/.linuxbrew/Homebrew/Library/Taps/aws/homebrew-tap/Formula/aws-sam-cli.rb:8:8: C: Description is too long. It should be less than 80 characters. The current length is 84.
  desc "AWS SAM CLI 🐿 is a tool for local development and testing of Serverless applications"
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
/home/linuxbrew/.linuxbrew/Homebrew/Library/Taps/aws/homebrew-tap/Formula/aws-sam-cli.rb:8:9: C: [Corrected] Description shouldn't start with the formula name.
  desc "AWS SAM CLI 🐿 is a tool for local development and testing of Serverless applications"
        ^^^^^^^^^^^

0 files inspected, 2 offenses detected, 1 offense corrected
```