### PR TITLE
Release QLDB Shell v2.0.0-alpha4

### DIFF
--- a/bottle-configs/qldbshell.json
+++ b/bottle-configs/qldbshell.json
@@ -1,12 +1,12 @@
 {
   "name": "qldbshell",
-  "version": "2.0.0-alpha3",
+  "version": "2.0.0-alpha4",
   "bin": "qldb",
   "bottle": {
     "root_url": "https://github.com/awslabs/amazon-qldb-shell/releases/download/",
     "sha256": {
-      "sierra": "c41703dc1e7f98804f2fc1f3e4c83118ed6285629db9939e9f6ef39bc8ca98c9",
-      "linux": "3aea2610794a585e071a8270f0c4be5373c65614d62ad9f2e1d60e325df61b20"
+      "sierra": "ca108dc94dc2f4044b21a2bc91dac1fd32d7f395e3919c2aa4967142a1556dd0",
+      "linux": "7058bb487eb8a0c2acbe434df9f17fdbbd1f6ad39f26f1415067d018cad265dc"
     }
   }
 }

--- a/bottle-configs/qldbshell.json
+++ b/bottle-configs/qldbshell.json
@@ -1,12 +1,12 @@
 {
   "name": "qldbshell",
-  "version": "2.0.9",
+  "version": "2.0.0-alpha3",
   "bin": "qldb",
   "bottle": {
     "root_url": "https://github.com/awslabs/amazon-qldb-shell/releases/download/",
     "sha256": {
-      "sierra": "566ec6e51c8774e09fe26746cfc1f72130c9db20918ef31143ea679708889adc",
-      "linux": "2bdc439fcfb3c12c21faaae1f096f4b80d6af701a842f1ff9532ce0221bddeb2"
+      "sierra": "c41703dc1e7f98804f2fc1f3e4c83118ed6285629db9939e9f6ef39bc8ca98c9",
+      "linux": "3aea2610794a585e071a8270f0c4be5373c65614d62ad9f2e1d60e325df61b20"
     }
   }
 }

--- a/bottle-configs/qldbshell.json
+++ b/bottle-configs/qldbshell.json
@@ -5,8 +5,8 @@
   "bottle": {
     "root_url": "https://github.com/awslabs/amazon-qldb-shell/releases/download/",
     "sha256": {
-      "sierra": "ca108dc94dc2f4044b21a2bc91dac1fd32d7f395e3919c2aa4967142a1556dd0",
-      "linux": "7058bb487eb8a0c2acbe434df9f17fdbbd1f6ad39f26f1415067d018cad265dc"
+      "sierra": "d13a23d4157d3760c3532ff2ca352a4e48202dadf70ddcb323a7b8c4f057e6e8",
+      "linux": "00ed468820255f6dce8872f81c4d037987da73a1612f46e0555c81bec208cca6"
     }
   }
 }


### PR DESCRIPTION
This change brings the latest improvements to the QLDB Shell to Homebrew.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
