### PR TITLE
chore: update k8s-tools binary to avoid conflicts with container-tools

### DIFF
--- a/Formula/k8s-tools.rb
+++ b/Formula/k8s-tools.rb
@@ -1,7 +1,7 @@
 class K8sTools < Formula
     desc "Meta Package for common Kubernetes tools"
-    version "1.0.0"
-    homepage "https://github.com/aws/"
+    version "1.0.1"
+    homepage "https://github.com/aws/homebrew-tap"
     bottle :unneeded
     url "file:///dev/null"
     sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
@@ -15,7 +15,7 @@ class K8sTools < Formula
     depends_on "kustomize"
 
     def install
-        (bin+"awscontainertools").write <<-EOS
+        (bin+"awsk8stools").write <<-EOS
             #!/bin/sh
 
             echo "Kubernetes tools installed"


### PR DESCRIPTION
*Description of changes:*
The k8s-tools fails to install unless you manually override the `awscontainertools` binary link. This renames it to avoid name conflict.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
