### PR TITLE
Fix eks-anywhere formula on arm

### DIFF
--- a/Formula/eks-anywhere.rb
+++ b/Formula/eks-anywhere.rb
@@ -1,26 +1,33 @@
 class EksAnywhere < Formula
-    desc "CLI for managing EKS Anywhere Kubernetes clusters"
-    homepage "https://github.com/aws/eks-anywhere"
-    version "0.5.0"
-    bottle :unneeded
+  desc "CLI for managing EKS Anywhere Kubernetes clusters"
+  homepage "https://github.com/aws/eks-anywhere"
+  version "0.5.0"
+  bottle :unneeded
 
-    on_macos do
-      if Hardware::CPU.intel?
-        url "https://anywhere-assets.eks.amazonaws.com/releases/eks-a/1/artifacts/eks-a/v0.5.0/darwin/eksctl-anywhere-v0.5.0-darwin-amd64.tar.gz"
-        sha256 "ed7790c706216b531a5f844529142d734b52b538d15dc4f6bc7cbf0e717ab0cd"
-      end
-    end
+  if OS.mac?
+    url "https://anywhere-assets.eks.amazonaws.com/releases/eks-a/1/artifacts/eks-a/v0.5.0/darwin/eksctl-anywhere-v0.5.0-darwin-amd64.tar.gz"
+    sha256 "ed7790c706216b531a5f844529142d734b52b538d15dc4f6bc7cbf0e717ab0cd"
+  end
 
-    on_linux do
-      if Hardware::CPU.intel?
-        url "https://anywhere-assets.eks.amazonaws.com/releases/eks-a/1/artifacts/eks-a/v0.5.0/linux/eksctl-anywhere-v0.5.0-linux-amd64.tar.gz"
-        sha256 "020ae9fb3b01070bda29e530d157089bf56e11245bde098118ea0350ed5f5ec4"
-      end
-    end
+  if OS.linux?
+    url "https://anywhere-assets.eks.amazonaws.com/releases/eks-a/1/artifacts/eks-a/v0.5.0/linux/eksctl-anywhere-v0.5.0-linux-amd64.tar.gz"
+    sha256 "020ae9fb3b01070bda29e530d157089bf56e11245bde098118ea0350ed5f5ec4"
+  end
 
-    depends_on "eksctl"
-
-    def install
-      bin.install "eksctl-anywhere"
+  if Hardware::CPU.arm?
+    def caveats
+      <<~EOF
+          =====WARNING=====
+          ARM CPU's are not yet supported.
+          The amd64 binary has been installed but will not work.
+          Please uninstall this formula.
+      EOF
     end
   end
+
+  depends_on "eksctl"
+
+  def install
+    bin.install "eksctl-anywhere"
+  end
+end


### PR DESCRIPTION
*Issue #, if available:*

Fixes #228

*Description of changes:*

This PR fixes an issue with the eks-anywhere formula under ARM CPU's while we figure out a proper fix. This will install the amd64 version but warn the user that it will not work and the the formula should be uninstalled.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.