### PR TITLE
Release v2.0.0-alpha14 of the QLDB Shell

### DIFF
--- a/bottle-configs/qldbshell.json
+++ b/bottle-configs/qldbshell.json
@@ -1,13 +1,13 @@
 {
   "name": "qldbshell",
-  "version": "2.0.0-alpha12",
+  "version": "2.0.0-alpha14",
   "bin": "qldb",
   "bottle": {
     "root_url": "https://github.com/awslabs/amazon-qldb-shell/releases/download/",
     "sha256": {
       "arm64_big_sur": "",
-      "sierra": "b683eb44468eb0913e9c150d801df7cbd453dcc084e6c957e18ab67efc67f92e",
-      "linux": "48a0b178153e70157d4349c216ac8e3c7e607cb61a90de7ac34e3fdf67849e1e"
+      "sierra": "b620d8392d084a6b65907e0daa281279c1f01dbda7f5417efde8012fb3c4f66e",
+      "linux": "d5b5ffdc953662a96fcbd7967eb7910bd4ea927646c52517df188778bbfe2726"
     }
   }
 }


### PR DESCRIPTION
Update the bottle configs for QLDB Shell v2.0.0-alpha14 release.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
