### PR TITLE
Upgrade to lightsailctl 1.0.2

### DIFF
--- a/Formula/lightsailctl.rb
+++ b/Formula/lightsailctl.rb
@@ -14,7 +14,16 @@ class Lightsailctl < Formula
 
     depends_on "go" => :build
 
+    option "with-goproxy-direct",
+           "Obtain source code of lightsailctl's dependencies directly\n\t" + 
+           "from the respective version control systems, bypassing\n\t" +
+           "proxy.golang.org module proxy"
+
     def install
+        if build.with? "goproxy-direct"
+            ENV["GOPROXY"] = "direct"
+        end
+
         system "go", "build", "-trimpath", "-o", bin/$config_provider.bin, "main.go"
     end
 

--- a/Formula/lightsailctl.rb
+++ b/Formula/lightsailctl.rb
@@ -15,7 +15,7 @@ class Lightsailctl < Formula
     depends_on "go" => :build
 
     def install
-        system "go", "build", "-trimpath", "-o", bin/$config_provider.bin, "cmd/lightsailctl/main.go"
+        system "go", "build", "-trimpath", "-o", bin/$config_provider.bin, "main.go"
     end
 
     test do

--- a/bottle-configs/lightsailctl.json
+++ b/bottle-configs/lightsailctl.json
@@ -1,7 +1,7 @@
 {
-    "version": "1.0.1",
-    "url": "https://github.com/aws/lightsailctl/archive/v1.0.1.tar.gz",
-    "sha256": "e220fba3d9fe69f293b5263a2f653fd894558269511044d83b2d3c3782b4a801",
+    "version": "1.0.2",
+    "url": "https://github.com/aws/lightsailctl/archive/v1.0.2.tar.gz",
+    "sha256": "30538f029e7c1e67d189c175b725348d33aa4c984ae79cbf7945298c48c734f3",
     "name": "lightsailctl",
     "bin": "lightsailctl"
 }


### PR DESCRIPTION
- Update version and sha256 accordingly
- Update the build command to reflect the new location of `main.go`
- Add `with-goproxy-direct` option that lets customers bypass `proxy.golang.org` module proxy
  when installing `lightsailctl` from networks where this module proxy is blocked

## Testing

```sh
$ brew test lightsailctl
==> Testing aws/tap/lightsailctl
==> /usr/local/Cellar/lightsailctl/1.0.2/bin/lightsailctl --plugin --help 2>&1
```