### PR TITLE
Correct version number for qldb shell

### DIFF
--- a/bottle-configs/qldbshell.json
+++ b/bottle-configs/qldbshell.json
@@ -1,6 +1,6 @@
 {
   "name": "qldbshell",
-  "version": "2.0.0-alpha14",
+  "version": "2.0.0",
   "bin": "qldb",
   "bottle": {
     "root_url": "https://github.com/awslabs/amazon-qldb-shell/releases/download/",


### PR DESCRIPTION
release qldb shell 2.0.0

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
