### PR TITLE
chore: Remove the deprecated 'bottle :unneeded'

### DIFF
--- a/Formula/copilot-cli.rb
+++ b/Formula/copilot-cli.rb
@@ -7,7 +7,6 @@ class CopilotCli < Formula
     desc "Copilot CLI - build, release and operate your container apps on AWS"
     homepage "https://aws.github.io/copilot-cli/"
     version $config_provider.version
-    bottle :unneeded
 
     if OS.mac?
       if Hardware::CPU.intel?


### PR DESCRIPTION
This will address the following warning from Homebrew:

> `Warning: Calling bottle :unneeded is deprecated! There is no replacement.`

