### PR TITLE
remove bottle unneeded from formulas

### DIFF
--- a/Formula/aws-simple-ec2-cli.rb
+++ b/Formula/aws-simple-ec2-cli.rb
@@ -8,7 +8,6 @@ class AwsSimpleEc2Cli < Formula
   desc "AWS Simple EC2 CLI is a tool that simplifies the process of launching, connecting and terminating an EC2 instance"
   homepage "https://github.com/awslabs/aws-simple-ec2-cli/"
   version $config_provider.version
-  bottle :unneeded
 
   if OS.mac?
     url "#{$config_provider.root_url}-darwin-amd64.tar.gz"

--- a/Formula/container-tools.rb
+++ b/Formula/container-tools.rb
@@ -2,7 +2,6 @@ class ContainerTools < Formula
     desc "Meta Package for common AWS Container tools"
     version "1.0.0"
     homepage "https://github.com/aws/"
-    bottle :unneeded
     url "file:///dev/null"
     sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
 

--- a/Formula/ec2-instance-selector.rb
+++ b/Formula/ec2-instance-selector.rb
@@ -8,7 +8,6 @@ class Ec2InstanceSelector < Formula
   desc "EC2 Instance Selector is a tool to filter EC2 instance types based on resource criteria"
   homepage "https://github.com/aws/amazon-ec2-instance-selector/"
   version $config_provider.version
-  bottle :unneeded
 
   if OS.mac?
     if Hardware::CPU.intel?

--- a/Formula/ec2-metadata-mock.rb
+++ b/Formula/ec2-metadata-mock.rb
@@ -8,7 +8,6 @@ class Ec2MetadataMock < Formula
   desc "EC2 Metadata Mock is a testing tool to mock out the EC2 Instance Metadata Service"
   homepage "https://github.com/aws/amazon-ec2-metadata-mock/"
   version $config_provider.version
-  bottle :unneeded
 
   if OS.mac?
     if Hardware::CPU.intel?

--- a/Formula/eks-anywhere.rb
+++ b/Formula/eks-anywhere.rb
@@ -2,7 +2,6 @@ class EksAnywhere < Formula
   desc "CLI for managing EKS Anywhere Kubernetes clusters"
   homepage "https://github.com/aws/eks-anywhere"
   version "0.5.0"
-  bottle :unneeded
 
   if OS.mac?
     url "https://anywhere-assets.eks.amazonaws.com/releases/eks-a/1/artifacts/eks-a/v0.5.0/darwin/eksctl-anywhere-v0.5.0-darwin-amd64.tar.gz"

--- a/Formula/emr-on-eks-custom-image.rb
+++ b/Formula/emr-on-eks-custom-image.rb
@@ -8,7 +8,6 @@ class EmrOnEksCustomImage < Formula
   desc "Amazon EMR on EKS Custom Image CLI"
   homepage "https://github.com/awslabs/amazon-emr-on-eks-custom-image-cli"
   version $config_provider.version
-  bottle :unneeded
   license "Apache-2.0"
 
   if OS.mac?

--- a/Formula/k8s-tools.rb
+++ b/Formula/k8s-tools.rb
@@ -2,7 +2,6 @@ class K8sTools < Formula
     desc "Meta Package for common Kubernetes tools"
     version "1.0.1"
     homepage "https://github.com/aws/homebrew-tap"
-    bottle :unneeded
     url "file:///dev/null"
     sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
 

--- a/Formula/qldbshell.rb
+++ b/Formula/qldbshell.rb
@@ -8,7 +8,6 @@ class Qldbshell < Formula
   desc "A CLI for interacting with QLDB ledgers"
   homepage "https://github.com/awslabs/amazon-qldb-shell"
   version $config_provider.version
-  bottle :unneeded
 
   if OS.mac?
     # e.g. https://github.com/awslabs/amazon-qldb-shell/releases/download/v2.0.9/qldb-v2.0.9-mac.tar.gz

--- a/Formula/xray-daemon.rb
+++ b/Formula/xray-daemon.rb
@@ -8,7 +8,6 @@ class XrayDaemon < Formula
   desc "The AWS X-Ray daemon listens for traffic on UDP port 2000, gathers raw segment data, and relays it to the AWS X-Ray API."
   homepage "https://github.com/aws/aws-xray-daemon/"
   version $config_provider.version
-  bottle :unneeded
 
   if OS.mac?
     url "#{$config_provider.root_url}/aws-xray-daemon-macos-#{$config_provider.version}.zip"


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
`bottle :unneeded` is now unneeded (pun most certainly intended) 

```
Warning: Calling bottle :unneeded is deprecated! There is no replacement.
Please report this issue to the bwagner5/wagner tap (not Homebrew/brew or Homebrew/core):
  /usr/local/Homebrew/Library/Taps/bwagner5/homebrew-wagner/ds.rb:5

Warning: Calling bottle :unneeded is deprecated! There is no replacement.
Please report this issue to the bwagner5/tap tap (not Homebrew/brew or Homebrew/core):
  /usr/local/Homebrew/Library/Taps/bwagner5/homebrew-tap/Formula/ec2-instance-selector.rb:11
```

This PR removes `bottle :unneeded` from all formulas using it. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
