### PR TITLE
Add kubectl dependency

### DIFF
--- a/Formula/eks-anywhere.rb
+++ b/Formula/eks-anywhere.rb
@@ -25,6 +25,7 @@ class EksAnywhere < Formula
   end
 
   depends_on "eksctl"
+  depends_on "kubernetes-cli"
 
   def install
     bin.install "eksctl-anywhere"


### PR DESCRIPTION
Is missing from the upstream eksctl formula so we can add it here.

*Issue #, if available:*

*Description of changes:*
Adds kubectl to the eks-anywhere dependencies.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
