### PR TITLE
chore: update EKS Anywhere homebrew formula to v0.7.0

### DIFF
--- a/Formula/eks-anywhere.rb
+++ b/Formula/eks-anywhere.rb
@@ -1,16 +1,16 @@
 class EksAnywhere < Formula
   desc "CLI for managing EKS Anywhere Kubernetes clusters"
   homepage "https://github.com/aws/eks-anywhere"
-  version "0.6.1"
+  version "0.7.0"
 
   if OS.mac?
-    url "https://anywhere-assets.eks.amazonaws.com/releases/eks-a/3/artifacts/eks-a/v0.6.1/darwin/eksctl-anywhere-v0.6.1-darwin-amd64.tar.gz"
-    sha256 "f21d324b37954f483a3467018ec7cd85d7829a87a70a845462378bc48efbe1f2"
+    url "https://anywhere-assets.eks.amazonaws.com/releases/eks-a/5/artifacts/eks-a/v0.7.0/darwin/amd64/eksctl-anywhere-v0.7.0-darwin-amd64.tar.gz"
+    sha256 "1c918f513ed34506177d2b9afc1a7124ea42fa42c692fd4adfaf2d0494a1c1e6"
   end
 
   if OS.linux?
-    url "https://anywhere-assets.eks.amazonaws.com/releases/eks-a/3/artifacts/eks-a/v0.6.1/linux/eksctl-anywhere-v0.6.1-linux-amd64.tar.gz"
-    sha256 "9571f13abb08672acf0b144e4c21138d59d32cdcdf1e22b27a38e0fb5ebb6bfa"
+    url "https://anywhere-assets.eks.amazonaws.com/releases/eks-a/5/artifacts/eks-a/v0.7.0/linux/amd64/eksctl-anywhere-v0.7.0-linux-amd64.tar.gz"
+    sha256 "2484f00bafdb860d418557fec5e7ab660647a0316ae541cdd58f0166a30cfa05"
   end
 
   if Hardware::CPU.arm?


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Hey, hope you're well. I'm a member of EKS Anywhere, and we just completed our latest release, `v0.7.0`: https://github.com/aws/eks-anywhere/releases/tag/v0.7.0

We'd like to update the AWS homebrew tap to reflect this new release.

Thanks!

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
