### PR TITLE
chore: update eks anywhere homebrew formula to v0.7.2

### DIFF
--- a/Formula/eks-anywhere.rb
+++ b/Formula/eks-anywhere.rb
@@ -1,16 +1,16 @@
 class EksAnywhere < Formula
   desc "CLI for managing EKS Anywhere Kubernetes clusters"
   homepage "https://github.com/aws/eks-anywhere"
-  version "0.7.0"
+  version "0.7.2"
 
   if OS.mac?
-    url "https://anywhere-assets.eks.amazonaws.com/releases/eks-a/5/artifacts/eks-a/v0.7.0/darwin/amd64/eksctl-anywhere-v0.7.0-darwin-amd64.tar.gz"
-    sha256 "1c918f513ed34506177d2b9afc1a7124ea42fa42c692fd4adfaf2d0494a1c1e6"
+    url "https://anywhere-assets.eks.amazonaws.com/releases/eks-a/5/artifacts/eks-a/v0.7.2/darwin/amd64/eksctl-anywhere-v0.7.2-darwin-amd64.tar.gz"
+    sha256 "f1f7e06ecdb5320d8842d42bac0a65a53602f64c163ad7288d8672494809e017"
   end
 
   if OS.linux?
-    url "https://anywhere-assets.eks.amazonaws.com/releases/eks-a/5/artifacts/eks-a/v0.7.0/linux/amd64/eksctl-anywhere-v0.7.0-linux-amd64.tar.gz"
-    sha256 "2484f00bafdb860d418557fec5e7ab660647a0316ae541cdd58f0166a30cfa05"
+    url "https://anywhere-assets.eks.amazonaws.com/releases/eks-a/5/artifacts/eks-a/v0.7.2/linux/amd64/eksctl-anywhere-v0.7.2-linux-amd64.tar.gz"
+    sha256 "561cb2621a1aced5ef09b6c2f28ea9c1dd3bac8dd08e5c6944d1e339ee5b92f9"
   end
 
   if Hardware::CPU.arm?


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This PR updates the  AWS homebrew tap's EKS Anywhere formula to the latest [release v0.7.2](https://github.com/aws/eks-anywhere/releases/tag/v0.7.2)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
