### PR TITLE
Fix EKS Anywhere download link for v0.7.2

### DIFF
--- a/Formula/eks-anywhere.rb
+++ b/Formula/eks-anywhere.rb
@@ -4,12 +4,12 @@ class EksAnywhere < Formula
   version "0.7.2"
 
   if OS.mac?
-    url "https://anywhere-assets.eks.amazonaws.com/releases/eks-a/5/artifacts/eks-a/v0.7.2/darwin/amd64/eksctl-anywhere-v0.7.2-darwin-amd64.tar.gz"
+    url "https://anywhere-assets.eks.amazonaws.com/releases/eks-a/7/artifacts/eks-a/v0.7.2/darwin/amd64/eksctl-anywhere-v0.7.2-darwin-amd64.tar.gz"
     sha256 "f1f7e06ecdb5320d8842d42bac0a65a53602f64c163ad7288d8672494809e017"
   end
 
   if OS.linux?
-    url "https://anywhere-assets.eks.amazonaws.com/releases/eks-a/5/artifacts/eks-a/v0.7.2/linux/amd64/eksctl-anywhere-v0.7.2-linux-amd64.tar.gz"
+    url "https://anywhere-assets.eks.amazonaws.com/releases/eks-a/7/artifacts/eks-a/v0.7.2/linux/amd64/eksctl-anywhere-v0.7.2-linux-amd64.tar.gz"
     sha256 "561cb2621a1aced5ef09b6c2f28ea9c1dd3bac8dd08e5c6944d1e339ee5b92f9"
   end
 


### PR DESCRIPTION
This PR updates the download links for EKS Anywhere v0.7.2 tarballs for Darwin and Linux.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
