### PR TITLE
fix: remove --pre flag which is causing issues by installing preview dependencies

### DIFF
--- a/Formula/aws-sam-cli-nightly.rb
+++ b/Formula/aws-sam-cli-nightly.rb
@@ -22,7 +22,7 @@ class AwsSamCliNightly < Formula
   def install
     venv = virtualenv_create(libexec, "python3.8")
     system libexec/"bin/pip", "install", "--upgrade", "pip"
-    system libexec/"bin/pip", "install", "-v", "--pre", "--ignore-installed", buildpath
+    system libexec/"bin/pip", "install", "-v", "--ignore-installed", buildpath
     system libexec/"bin/pip", "uninstall", "-y", "aws-sam-cli"
     # bin folder is not created automatically
     bin.mkpath


### PR DESCRIPTION
*Issue #, if available:*

https://github.com/aws/aws-sam-cli/issues/3769

*Description of changes:*

`--pre` flag causes some preview dependencies to be installed. This change is targeting to fix it by removing that flag.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
