### PR TITLE
Removing the --pre flag which causes installation issues

### DIFF
--- a/Formula/aws-sam-cli-beta-cdk.rb
+++ b/Formula/aws-sam-cli-beta-cdk.rb
@@ -22,7 +22,7 @@ class AwsSamCliBetaCdk < Formula
   def install
     venv = virtualenv_create(libexec, "python3.8")
     system libexec/"bin/pip", "install", "--upgrade", "pip"
-    system libexec/"bin/pip", "install", "-v", "--pre", "--ignore-installed", buildpath
+    system libexec/"bin/pip", "install", "-v", "--ignore-installed", buildpath
     system libexec/"bin/pip", "uninstall", "-y", "aws-sam-cli"
     # bin folder is not created automatically
     bin.mkpath

--- a/Formula/aws-sam-cli-rc.rb
+++ b/Formula/aws-sam-cli-rc.rb
@@ -24,7 +24,7 @@ class AwsSamCliRc < Formula
   def install
     venv = virtualenv_create(libexec, "python3.7")
     system libexec/"bin/pip", "install", "pip==19.2.3"
-    system libexec/"bin/pip", "install", "-v", "--pre", "--ignore-installed", buildpath
+    system libexec/"bin/pip", "install", "-v", "--ignore-installed", buildpath
     system libexec/"bin/pip", "uninstall", "-y", "aws-sam-cli"
     venv.pip_install_and_link buildpath
   end


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/aws-sam-cli/issues/3799

*Description of changes:*
--pre flag causes some preview dependencies to be installed. This change is targeting to fix it by removing that flag.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
