### PR TITLE
Remove extra curly brace that caused parsing error for simple-ec2

### DIFF
--- a/bottle-configs/aws-simple-ec2-cli.json
+++ b/bottle-configs/aws-simple-ec2-cli.json
@@ -11,5 +11,4 @@
             "linux_arm": "aad9f9f83240c5e3d2b717ca1174c50fcdf49a9c5d673eb185e7642c43ab909c"
         }
     }
-  }
 }


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*

Syntax error from manually modifying the JSON file in the previous commit 🤦

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
