### PR TITLE
cbmc-viewer: change python 3.9->3.7, remove universal-ctags

### DIFF
--- a/Formula/cbmc-viewer.rb
+++ b/Formula/cbmc-viewer.rb
@@ -15,8 +15,7 @@ class CbmcViewer < Formula
   end
 
   depends_on "cbmc" => :test
-  depends_on "python@3.9"
-  depends_on "universal-ctags"
+  depends_on "python@3.7"
 
   resource "Jinja2" do
     url "https://files.pythonhosted.org/packages/91/a5/429efc6246119e1e3fbf562c00187d04e83e54619249eb732bb423efa6c6/Jinja2-3.0.3.tar.gz"


### PR DESCRIPTION
This changes the python required from 3.9 to 3.7 and removes universal-ctags as a dependency.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
