### PR TITLE
Modify cbmc-viewer formula to depend on python@3.8.

### DIFF
--- a/Formula/cbmc-viewer.rb
+++ b/Formula/cbmc-viewer.rb
@@ -15,7 +15,7 @@ class CbmcViewer < Formula
   end
 
   depends_on "cbmc" => :test
-  depends_on "python@3.7"
+  depends_on "python@3.8"
   depends_on "universal-ctags" => :optional
 
   resource "Jinja2" do


### PR DESCRIPTION
Depending on python@3.7 is a problem on M1.  Doing

```
brew uninstall cbmc-viewer
brew update-reset
brew install cbmc-viewer
```

on M1 generates the error message

```
python@3.7: The x86_64 architecture is required for this software.
Error: cbmc-viewer: An unsatisfied requirement failed this build.
```

One issue may be that there is no M1 bottle for python@3.7 and pip
needs to build 3.7 from scratch on M1.  But this error exists on M1
even with brew python 3.9 installed, so there should be no need for
installing 3.7.  Requiring 3.8 seems to be enough to fix the problem.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
