### PR TITLE
Upgrade lightsailctl to 1.0.4

### DIFF
--- a/bottle-configs/lightsailctl.json
+++ b/bottle-configs/lightsailctl.json
@@ -1,7 +1,7 @@
 {
-    "version": "1.0.3",
-    "url": "https://github.com/aws/lightsailctl/archive/v1.0.3.tar.gz",
-    "sha256": "b3d4bee80a06815f429dd347bd67852ee2d6231253d146bb3da75af985c5b747",
+    "version": "1.0.4",
+    "url": "https://github.com/aws/lightsailctl/archive/v1.0.4.tar.gz",
+    "sha256": "be23b4694645d552d3074b0ecd94dd10ef863815cbd5c03dcd38c4d171f764ce",
     "name": "lightsailctl",
     "bin": "lightsailctl"
 }


### PR DESCRIPTION
See: <https://github.com/aws/lightsailctl/releases/tag/v1.0.4>

Passes the self test:
```
$ brew test lightsailctl
==> Testing aws/tap/lightsailctl
==> /usr/local/Cellar/lightsailctl/1.0.4/bin/lightsailctl --plugin --help 2>&1
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
