### PR TITLE
Upgrade qldbshell version to 2.0.2

### DIFF
--- a/bottle-configs/qldbshell.json
+++ b/bottle-configs/qldbshell.json
@@ -1,6 +1,6 @@
 {
   "name": "qldbshell",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "bin": "qldb",
   "bottle": {
     "root_url": "https://github.com/awslabs/amazon-qldb-shell/releases/download/",


### PR DESCRIPTION
The previous release commit updated the commit SHAs, but failed to bump the QLDB version.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
