### PR TITLE
fix: `aws-sam-cli` formula

### DIFF
--- a/Formula/aws-sam-cli.rb
+++ b/Formula/aws-sam-cli.rb
@@ -41,10 +41,7 @@ class AwsSamCli < Formula
 
     def install
       venv = virtualenv_create(libexec, "python3.8")
-      system libexec/"bin/pip", "install", "--upgrade", "pip"
-      system libexec/"bin/pip", "install", "-v", "--ignore-installed", buildpath
-      system libexec/"bin/pip", "uninstall", "-y", "aws-sam-cli"
-      venv.pip_install_and_link buildpath
+      venv.pip_install_and_link("aws-sam-cli")
     end
   end
 


### PR DESCRIPTION
- Allow to directly install from virtualenv.
- `venv.pip_install_and_link("aws-sam-cli")` -> `/opt/homebrew/Cellar/aws-sam-cli/1.65.0/libexec/bin/pip install -v --no-deps --no-binary :all: --ignore-installed aws-sam-cli` . The above command shows that it installs from source anyway without any binary links.

*Issue #, if available:*
- https://github.com/aws/homebrew-tap/issues/408
- https://github.com/aws/aws-sam-cli/issues/4405

*Description of changes:*

- Simpler way to build from source.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
