### PR TITLE
Smithy cli

### DIFF
--- a/Formula/smithy-cli.rb
+++ b/Formula/smithy-cli.rb
@@ -1,0 +1,50 @@
+# -*- coding: utf-8 -*-
+require_relative '../ConfigProvider/config_provider'
+
+class SmithyCli < Formula
+    $config_provider = ConfigProvider.new('smithy-cli')
+    desc "Smithy CLI - A CLI for building, validating, and iterating on Smithy models"
+    homepage "https://smithy.io"
+    version $config_provider.version
+
+    if OS.mac?
+      if Hardware::CPU.intel?
+        url "#{$config_provider.root_url}-darwin-x86_64.tar.gz"
+        sha256 $config_provider.sierra_hash
+      elsif Hardware::CPU.arm?
+        url "#{$config_provider.root_url}-darwin-aarch64.tar.gz"
+        sha256 $config_provider.arm64_big_sur_hash
+      end
+    elsif OS.linux?
+      if Hardware::CPU.intel?
+        url "#{$config_provider.root_url}-linux-x86_64.tar.gz"
+        sha256 $config_provider.linux_hash
+      elsif Hardware::CPU.arm?
+        url "#{$config_provider.root_url}-linux-aarch64.tar.gz"
+        sha256 $config_provider.linux_arm_hash
+      end
+    end
+
+    def install
+        # install everything in the archive
+        prefix.install Dir["*"]
+    end
+
+    def post_install
+        # brew relocates dylibs and assigns different ids, which is problematic since
+        # we package a runtime image ourselves
+        Dir["#{lib}/**/*.dylib"].each do |dylib|
+            chmod 0664, dylib
+            MachO::Tools.change_dylib_id(dylib, "@rpath/#{File.basename(dylib)}")
+            chmod 0444, dylib
+        end
+        # call warmup command to generate the jsa 
+        system "#{bin}/#{$config_provider.bin}" " warmup"
+    end
+
+    test do
+        assert_predicate lib/"#{$config_provider.bin}.jsa", :exist?
+        assert_match $config_provider.version, shell_output("#{bin}/#{$config_provider.bin} --version")
+        assert_match "Usage: #{$config_provider.bin}", shell_output("#{bin}/#{$config_provider.bin} --help")
+    end
+end

--- a/Formula/smithy-cli.rb
+++ b/Formula/smithy-cli.rb
@@ -3,7 +3,7 @@ require_relative '../ConfigProvider/config_provider'
 
 class SmithyCli < Formula
     $config_provider = ConfigProvider.new('smithy-cli')
-    desc "Smithy CLI - A CLI for building, validating, and iterating on Smithy models"
+    desc "Smithy CLI - A CLI for building, validating, querying, and iterating on Smithy models"
     homepage "https://smithy.io"
     version $config_provider.version
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ brew install <FORMULA>
 | [emr-on-eks-custom-image](https://github.com/awslabs/amazon-emr-on-eks-custom-image-cli) | [formula](Formula/emr-on-eks-custom-image.rb) | A CLI tool to interact with EMR on EKS custom images.
 | [cbmc-viewer](https://github.com/awslabs/aws-viewer-for-cbmc) | [formula](Formula/cbmc-viewer.rb) | CBMC Viewer scans the output of CBMC and produces a summary that can be opened in any web browser to understand and debug CBMC findings.
 | [dynamodb-shell](https://github.com/awslabs/dynamodb-shell) | [formula](Formula/aws-ddbsh.rb) | A simple SQL CLI for DynamoDB
-
+| [smithy-cli](https://github.com/awslabs/smithy) | [formula](Formula/smithy-cli.rb) | A CLI for building, validating, querying, and iterating on Smithy models
 ## Documentation
 
 `brew help`, `man brew` or check [Homebrew's documentation](https://docs.brew.sh/)

--- a/bottle-configs/smithy-cli.json
+++ b/bottle-configs/smithy-cli.json
@@ -1,0 +1,15 @@
+{
+  "version": "0",
+  "name": "smithy-cli",
+  "bin": "smithy",
+  "bottle": {
+    "root_url": "",
+    "sha256": {
+      "arm64_big_sur": "",
+      "sierra": "",
+      "linux": "",
+      "linux_arm": ""
+    }
+  }
+}
+

--- a/bottle-configs/smithy-cli.json
+++ b/bottle-configs/smithy-cli.json
@@ -1,14 +1,14 @@
 {
-  "version": "0",
+  "version": "1.30.0",
   "name": "smithy-cli",
   "bin": "smithy",
   "bottle": {
-    "root_url": "",
+    "root_url": "https://github.com/awslabs/smithy/releases/download/1.30.0/smithy-cli",
     "sha256": {
-      "arm64_big_sur": "",
-      "sierra": "",
-      "linux": "",
-      "linux_arm": ""
+      "arm64_big_sur": "ba0379aec0b37626972e481545d5000ddb340443b881be6128bffa9ff2c2f68e",
+      "sierra": "2dd8ec34b5419588d1285e1d2897b2487377fd2346ca54d93cf219cdeafa8b4e",
+      "linux": "8d266240f081989d339600a15d456a1d5104e3267a45e7f836e02a4ecfcb780a",
+      "linux_arm": "8e61ec88ee2351ff7ac0f1053957f4c086306b5c1bed89f583c3cf1aad6e4da4"
     }
   }
 }


### PR DESCRIPTION
*Description of changes:*
With the publishing of smithy-cli artifacts to GitHub, we'd like to vend the cli through homebrew as well

The smithy repository is under awslabs (for now), and would like to use the official aws tap to vend through homebrew

We will add automation to keep the bottle-config up-to-date with the latest releases in the smithy repo.


*Testing:*
I have tested via brew and confirmed working as expected

```
brew install --build-from-source Formula/smithy-cli.rb --verbose --debug
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
