### PR TITLE
fix: re-codesign smithy-cli dylibs for apple silicon

### DIFF
--- a/Formula/smithy-cli.rb
+++ b/Formula/smithy-cli.rb
@@ -36,6 +36,7 @@ class SmithyCli < Formula
         Dir["#{lib}/**/*.dylib"].each do |dylib|
             chmod 0664, dylib
             MachO::Tools.change_dylib_id(dylib, "@rpath/#{File.basename(dylib)}")
+            MachO.codesign!(dylib) if Hardware::CPU.arm?
             chmod 0444, dylib
         end
         # call warmup command to generate the jsa 


### PR DESCRIPTION
*Description of changes:*
Installing smithy-cli on M1 silicon led to gatekeeper preventing the executables from running, 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


*Testing:*
Pulled the repo in locally on an M1 mac, ran install (`brew install --build-from-source Formula/smithy-cli.rb --verbose --debug`) without changes, observe that install fails
- check dmesg and see:
```
[510073.159981]: arm64e_plugin_host: running binary "bash" in keys-off mode due to identity: com.apple.bashCODE SIGNING: process 75181[java]: rejecting invalid page at address 0x102574000 from offset 0x0 in file "/opt/homebrew/Cellar/smithy-cli/1.30.0/lib/libjli.dylib" (cs_mtime:1682010630.160538997 == mtime:1682010630.160538997) (signed:1 validated:1 tainted:1 nx:0 wpmapped:0 dirty:0 depth:0)
```

Add change to re-sign after changing dylib-id, run install (`brew install --build-from-source Formula/smithy-cli.rb --verbose --debug`), and observe install succeeds and cli runs without issue