### PR TITLE
fix: constrain smithy-cli dylib globs

### DIFF
--- a/Formula/smithy-cli.rb
+++ b/Formula/smithy-cli.rb
@@ -33,7 +33,7 @@ class SmithyCli < Formula
     def post_install
         # brew relocates dylibs and assigns different ids, which is problematic since
         # we package a runtime image ourselves
-        Dir["#{lib}/**/*.dylib"].each do |dylib|
+        Dir["#{lib}/smithy-cli/**/*.dylib"].each do |dylib|
             chmod 0664, dylib
             MachO::Tools.change_dylib_id(dylib, "@rpath/#{File.basename(dylib)}")
             MachO.codesign!(dylib) if Hardware::CPU.arm?


### PR DESCRIPTION
*Description of changes:*
Fix the globs for smithy-cli `post_install` steps for dylibs

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
