### PR TITLE
fix: make smithy-cli lib private, explicitly create bin symlink

### DIFF
--- a/Formula/smithy-cli.rb
+++ b/Formula/smithy-cli.rb
@@ -26,14 +26,18 @@ class SmithyCli < Formula
     end
 
     def install
-        # install everything in the archive
-        prefix.install Dir["*"]
+        # install everything in archive into libexec, so that
+        # the contents are private to homebrew, which means it won't try
+        # to symlink anything in this directory automatically
+        libexec.install Dir["*"]
+        # create a symlink to the private executable
+        bin.install_symlink "#{libexec}/bin/smithy" => "smithy"
     end
 
     def post_install
         # brew relocates dylibs and assigns different ids, which is problematic since
         # we package a runtime image ourselves
-        Dir["#{lib}/**/*.dylib"].each do |dylib|
+        Dir["#{libexec}/**/*.dylib"].each do |dylib|
             chmod 0664, dylib
             MachO::Tools.change_dylib_id(dylib, "@rpath/#{File.basename(dylib)}")
             MachO.codesign!(dylib) if Hardware::CPU.arm?


### PR DESCRIPTION
*Description of changes:*
Installing via `prefix.install` meant that brew would attempt to symlink all files, and this is problematic in smithy-cli's case because it's a bundled runtime image (and includes everything it needs to run without brew dependencies). 

Files in `libexec` are private to homebrew (meaning it won't try to symlink files to `/usr/local/...`), so we do need to tell it to create a symlink to the smithy executable (which it will add to `/usr/local/bin` as we want).
 
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
