### PR TITLE
Fix cbmc-starter-kit checksums

### DIFF
--- a/Formula/cbmc-starter-kit.rb
+++ b/Formula/cbmc-starter-kit.rb
@@ -10,8 +10,8 @@ class CbmcStarterKit < Formula
 
   bottle do
     root_url "https://github.com/model-checking/cbmc-starter-kit/releases/download/starterkit-2.10"
-    sha256 cellar: :any_skip_relocation, monterey:     "9530f664a46e028745bccb189c29aaddfbfa8af1f1ff6bf150a5b8e4633e7779"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "f9bff9301507c2c8af3918b568fe1100bf362611dba2004a19346ce00659fda7"
+    sha256 cellar: :any_skip_relocation, monterey: "530e469c4d02a04128efcd22177293ec59e04afa271144648185774aadbc7205"
+    sha256 cellar: :any_skip_relocation, x86_64_linux: "d7c29a533d8711b9a56694b7b37f19d2367e92d1bb15a8d1d5d93d04b686b6fc"
   end
 
   depends_on "python@3.10"


### PR DESCRIPTION
This commit fixes the checksums for the CBMC starter kit to match the 2.10 tarball (which is the version used since commit b86da88).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
