### PR TITLE
Revert "chore: update eks-anywhere formula for v0.16.0"

### DIFF
--- a/Formula/eks-anywhere.rb
+++ b/Formula/eks-anywhere.rb
@@ -1,16 +1,16 @@
 class EksAnywhere < Formula
   desc "CLI for managing EKS Anywhere Kubernetes clusters"
   homepage "https://github.com/aws/eks-anywhere"
-  version "0.16.0"
+  version "0.15.4"
 
   if OS.mac?
-    url "https://anywhere-assets.eks.amazonaws.com/releases/eks-a/39/artifacts/eks-a/v0.16.0/darwin/amd64/eksctl-anywhere-v0.16.0-darwin-amd64.tar.gz"
-    sha256 "4aa272abb125f3aa8beb1dba1c53f66044daae27d943d9b0a106164acbc9025f"
+    url "https://anywhere-assets.eks.amazonaws.com/releases/eks-a/38/artifacts/eks-a/v0.15.4/darwin/amd64/eksctl-anywhere-v0.15.4-darwin-amd64.tar.gz"
+    sha256 "a8947bc4b6aaa717b535f3a0fd2850b9814c46ce7d83c5ed55724d8d7a6ac411"
   end
 
   if OS.linux?
-    url "https://anywhere-assets.eks.amazonaws.com/releases/eks-a/39/artifacts/eks-a/v0.16.0/linux/amd64/eksctl-anywhere-v0.16.0-linux-amd64.tar.gz"
-    sha256 "21e5fe2230fd4757dd6e82e3e22f6bfb149ae2dfc5b62683a5d2ff553c917664"
+    url "https://anywhere-assets.eks.amazonaws.com/releases/eks-a/38/artifacts/eks-a/v0.15.4/linux/amd64/eksctl-anywhere-v0.15.4-linux-amd64.tar.gz"
+    sha256 "7716f64b1299e0d51172aa00ee26c025ef16ff86b7e047e93e08f1d41a7aec8f"
   end
 
   if Hardware::CPU.arm?


### PR DESCRIPTION
Reverts aws/homebrew-tap#472 due to prow post submit job failure

https://prow.eks.amazonaws.com/view/s3/prowdataclusterstack-316434458-prowbucket7c73355c-1n9f9v93wpjcm/logs/brew-update-postsubmit/1664724977850519552

https://prow.eks.amazonaws.com/view/s3/prowdataclusterstack-316434458-prowbucket7c73355c-1n9f9v93wpjcm/logs/brew-update-postsubmit/1664665417345404928