### PR TITLE
fix: Run brew update-reset for sam-nightly brew bottle build

### DIFF
--- a/appveyor-sam-cli-nightly.yml
+++ b/appveyor-sam-cli-nightly.yml
@@ -10,6 +10,7 @@ image:
 
 # scripts that are called at very beginning, before repo cloning
 init:
+  - brew update-reset
   - git config --global core.autocrlf input
 
 # scripts that run after cloning repository


### PR DESCRIPTION
*Description of changes:*
`brew update` is failing due to the error:
```
Error: Fetching /usr/local/Homebrew/Library/Taps/homebrew/homebrew-core failed!
```
Running `brew update-reset` based on https://stackoverflow.com/questions/54834266/error-fetching-usr-local-homebrew-library-taps-homebrew-homebrew-core-failed.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
