### PR TITLE
fix: Untap homebrew/cask and homebrew/core before running brew update

### DIFF
--- a/appveyor-sam-cli-nightly.yml
+++ b/appveyor-sam-cli-nightly.yml
@@ -10,8 +10,7 @@ image:
 
 # scripts that are called at very beginning, before repo cloning
 init:
-  - brew untap homebrew/cask
-  - brew update-reset
+  - brew untap homebrew/cask homebrew/core
   - git config --global core.autocrlf input
 
 # scripts that run after cloning repository

--- a/appveyor-sam-cli-nightly.yml
+++ b/appveyor-sam-cli-nightly.yml
@@ -10,6 +10,7 @@ image:
 
 # scripts that are called at very beginning, before repo cloning
 init:
+  - brew untap homebrew/cask
   - brew update-reset
   - git config --global core.autocrlf input
 


### PR DESCRIPTION
*Description of changes:*
brew bottle build is failing due to an issue while updating homebrew/cask (while running brew update). Based on the suggestions in https://github.com/orgs/Homebrew/discussions/4612, untapping before running `brew update` does not give this error.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
