### PR TITLE
fix: Force untap brew core and cask

### DIFF
--- a/appveyor-sam-cli-nightly.yml
+++ b/appveyor-sam-cli-nightly.yml
@@ -10,7 +10,7 @@ image:
 
 # scripts that are called at very beginning, before repo cloning
 init:
-  - brew untap homebrew/cask homebrew/core
+  - brew untap homebrew/cask homebrew/core --force
   - git config --global core.autocrlf input
 
 # scripts that run after cloning repository


### PR DESCRIPTION
*Description of changes:*
brew untap failed due to existing casks mono-mdk and powershell. Testing if brew untap --force works.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
