### PR TITLE
fix: Unset HOMEBREW_NO_INSTALL_FROM_API env var

### DIFF
--- a/appveyor-sam-cli-nightly.yml
+++ b/appveyor-sam-cli-nightly.yml
@@ -10,6 +10,7 @@ image:
 
 # scripts that are called at very beginning, before repo cloning
 init:
+  - unset HOMEBREW_NO_INSTALL_FROM_API # Needs to be unset to untap homebrew/core
   - brew untap homebrew/cask homebrew/core --force
   - git config --global core.autocrlf input
 


### PR DESCRIPTION
*Description of changes:*
`brew untap homebrew/cask` worked but `brew untap homebrew/core` gave an error. According to https://github.com/orgs/Homebrew/discussions/4612#discussioncomment-6314857, this env var needs to be unset. I tested this on my machine and it seems to work. According to the [docs](https://docs.brew.sh/Installation) this env var needs to be set for pre-4.0.0 versions to clone core/cask repos.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
