### PR TITLE
fix: sam cli nightly remove untap for brew core as it errors out

### DIFF
--- a/appveyor-sam-cli-nightly.yml
+++ b/appveyor-sam-cli-nightly.yml
@@ -10,8 +10,8 @@ image:
 
 # scripts that are called at very beginning, before repo cloning
 init:
-  - unset HOMEBREW_NO_INSTALL_FROM_API # Needs to be unset to untap homebrew/core
-  - brew untap homebrew/cask homebrew/core --force
+  - brew untap homebrew/cask --force
+  - brew update-reset
   - git config --global core.autocrlf input
 
 # scripts that run after cloning repository


### PR DESCRIPTION
*Description of changes:*
unsetting the env var does not work on AppVeyor. The brew issue is only happening for cask right now. Added back update-reset which resolved homebrew-core failures and force untap cask.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
