### PR TITLE
fix: Revert sam cli nightly brew workarounds as brew has fixed the issues

### DIFF
--- a/appveyor-sam-cli-nightly.yml
+++ b/appveyor-sam-cli-nightly.yml
@@ -10,8 +10,6 @@ image:
 
 # scripts that are called at very beginning, before repo cloning
 init:
-  - brew untap homebrew/cask --force
-  - brew update-reset
   - git config --global core.autocrlf input
 
 # scripts that run after cloning repository


### PR DESCRIPTION
*Description of changes:*
Reverts the changes to sync with aws sam cli yaml file as these changes succeeded  during the prod release https://ci.appveyor.com/project/AWSSAMCLI/homebrew-tap/builds/47483334. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
