### PR TITLE
Upgrade lightsailctl to 1.0.6

### DIFF
--- a/bottle-configs/lightsailctl.json
+++ b/bottle-configs/lightsailctl.json
@@ -1,7 +1,7 @@
 {
-    "version": "1.0.5",
-    "url": "https://github.com/aws/lightsailctl/archive/v1.0.5.tar.gz",
-    "sha256": "82d31b309eabb52b344e480fc77110abb745d8780b8b0c1e80f75f93ad6d374c",
+    "version": "1.0.6",
+    "url": "https://github.com/aws/lightsailctl/archive/v1.0.6.tar.gz",
+    "sha256": "f967a4059833945418366284e8a3393518d21d636165182691d7bbf2f01cea1c",
     "name": "lightsailctl",
     "bin": "lightsailctl"
 }


### PR DESCRIPTION
See: <https://github.com/aws/lightsailctl/releases/tag/v1.0.6>

Passes the self test:

```
$ brew test lightsailctl 
==> Testing aws/tap/lightsailctl
==> /opt/homebrew/Cellar/lightsailctl/1.0.6/bin/lightsailctl --plugin --help 2>&1
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
