### PR TITLE
fix: Added workaround to address cython breaking PyYAML build

### DIFF
--- a/Formula/aws-sam-cli.rb
+++ b/Formula/aws-sam-cli.rb
@@ -42,6 +42,12 @@ class AwsSamCli < Formula
     def install
       venv = virtualenv_create(libexec, "python3.8")
       system libexec/"bin/pip", "install", "--upgrade", "pip"
+      # work around cython 3.0.0 breaking pyyaml
+      # https://github.com/yaml/pyyaml/issues/724
+      system libexec/"bin/pip", "install", "wheel"
+      system libexec/"bin/pip", "install", "--no-build-isolation", "cython<3.0.0", "pyyaml==5.4.1"
+      system libexec/"bin/pip", "uninstall", "wheel", "cython", "--yes"
+      # end work around
       system libexec/"bin/pip", "install", "-v", "--ignore-installed", buildpath
       system libexec/"bin/pip", "uninstall", "-y", "aws-sam-cli"
       venv.pip_install_and_link buildpath


### PR DESCRIPTION
*Issue #, if available:*
Related:
https://github.com/yaml/pyyaml/issues/724
https://github.com/aws/aws-sam-cli/pull/5494

*Description of changes:*
`cython==3.0.0` breaks `PyYAML` when building from source. The change here is to install a lower version of `cython` and install `PyYAML` using that version before installing the rest of the dependencies from AWS SAM CLI.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
