### PR TITLE
fix aws-sam-cli linux sha with latest release

### DIFF
--- a/bottle-configs/aws-sam-cli.json
+++ b/bottle-configs/aws-sam-cli.json
@@ -14,7 +14,7 @@
         "root_url": "https://github.com/aws/aws-sam-cli/releases/download/v1.93.0/",
         "linux_x86": {
             "file": "aws-sam-cli-linux-x86_64.zip",
-            "sha256": "3207956aa42e404b266ef1b48fdf6883d89af9e812b0fac84bdd6ee8d88eb034"
+            "sha256": "c9a4ef24ffffac62f040323dcabd3fcab443bac6f3eb003efa5c49b3f29604a4"
         }
     }
 }


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Linux configuration has the sha value of `.sig` file where it should be the `.zip` one. This PR fixes that issue.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
