### PR TITLE
add warning message for sam cli deprecation

### DIFF
--- a/Formula/aws-sam-cli.rb
+++ b/Formula/aws-sam-cli.rb
@@ -52,4 +52,8 @@ class AwsSamCli < Formula
     assert_match "Usage", shell_output("#{bin}/sam --help")
     system bin/"sam --version"
   end
+
+  opoo "SAM CLI will no longer support installing through aws/tap/aws-sam-cli. 
+        Please consider using supported installers, for more information 
+        https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/install-sam-cli.html"
 end


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/aws-sam-cli/issues/5613

*Description of changes:*
Adds warning message during `aws-sam-cli` installation for upcoming deprecation.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
