### PR TITLE
fix: update warning messages

### DIFF
--- a/Formula/aws-sam-cli-nightly.rb
+++ b/Formula/aws-sam-cli-nightly.rb
@@ -52,4 +52,7 @@ class AwsSamCliNightly < Formula
     assert_match "Usage", shell_output("#{bin}/sam-nightly --help")
     system bin/"sam-nightly --version"
   end
+
+  opoo "On September 12, 2023, AWS will no longer maintain Homebrew installer for nightly version of AWS SAM CLI (aws/tap/aws-sam-cli-nightly). 
+        For AWS supported installations, use the first-party installers (https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/manage-sam-cli-versions.html#manage-sam-cli-versions-nightly-build)."
 end

--- a/Formula/aws-sam-cli-nightly.rb
+++ b/Formula/aws-sam-cli-nightly.rb
@@ -53,6 +53,6 @@ class AwsSamCliNightly < Formula
     system bin/"sam-nightly --version"
   end
 
-  opoo "On September 12, 2023, AWS will no longer maintain Homebrew installer for nightly version of AWS SAM CLI (aws/tap/aws-sam-cli-nightly). 
+  opoo "On September 12, 2023, AWS will no longer maintain the Homebrew installer for nightly version of AWS SAM CLI (aws/tap/aws-sam-cli-nightly). 
         For AWS supported installations, use the first-party installers (https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/manage-sam-cli-versions.html#manage-sam-cli-versions-nightly-build)."
 end

--- a/Formula/aws-sam-cli.rb
+++ b/Formula/aws-sam-cli.rb
@@ -53,7 +53,7 @@ class AwsSamCli < Formula
     system bin/"sam --version"
   end
 
-  opoo "Starting from 2023/8/14, AWS SAM CLI will no longer support installing through aws/tap/aws-sam-cli. 
-        Please use supported installers, for more information 
-        https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/install-sam-cli.html"
+  opoo "On September 12, 2023, AWS will no longer maintain the Homebrew installer for AWS SAM CLI (aws/tap/aws-sam-cli). 
+        For AWS supported installations, use the first-party installers (https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/install-sam-cli.html). 
+        To continue using Homebrew, use the community supported installer (https://formulae.brew.sh/formula/aws-sam-cli)."
 end


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Updates warning message during installation.

Production warning;
```
Warning: On September 12, 2023, AWS will no longer maintain the Homebrew installer for AWS SAM CLI (aws/tap/aws-sam-cli).
        For AWS supported installations, use the first-party installers (https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/install-sam-cli.html).
        To continue using Homebrew, use the community supported installer (https://formulae.brew.sh/formula/aws-sam-cli).
```

Nightly warning;
```
Warning: On September 12, 2023, AWS will no longer maintain Homebrew installer for nightly version of AWS SAM CLI (aws/tap/aws-sam-cli-nightly).
        For AWS supported installations, use the first-party installers (https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/manage-sam-cli-versions.html#manage-sam-cli-versions-nightly-build).
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
