### PR TITLE
fix: Use the without_pip:false argument to include pip in venv

### DIFF
--- a/Formula/aws-sam-cli-nightly.rb
+++ b/Formula/aws-sam-cli-nightly.rb
@@ -38,7 +38,9 @@ class AwsSamCliNightly < Formula
     depends_on "python@3.8"
 
     def install
-      venv = virtualenv_create(libexec, "python3.8")
+      # https://github.com/Homebrew/brew/pull/15792
+      # re-add pip to the virtualenv using without_pip=false
+      venv = virtualenv_create(libexec, "python3.8", without_pip:false)
       system libexec/"bin/pip", "install", "--upgrade", "pip"
       system libexec/"bin/pip", "install", "-v", "--ignore-installed", buildpath
       system libexec/"bin/pip", "uninstall", "-y", "aws-sam-cli"

--- a/Formula/aws-sam-cli.rb
+++ b/Formula/aws-sam-cli.rb
@@ -40,7 +40,9 @@ class AwsSamCli < Formula
     depends_on "python@3.8"
 
     def install
-      venv = virtualenv_create(libexec, "python3.8")
+      # https://github.com/Homebrew/brew/pull/15792
+      # re-add pip to the virtualenv using without_pip=false
+      venv = virtualenv_create(libexec, "python3.8", without_pip:false)
       system libexec/"bin/pip", "install", "--upgrade", "pip"
       system libexec/"bin/pip", "install", "-v", "--ignore-installed", buildpath
       system libexec/"bin/pip", "uninstall", "-y", "aws-sam-cli"


### PR DESCRIPTION
*Issue #, if available:*
None.

*Description of changes:*
A recent change in brew caused virtual environments to not include `pip` by default unless an argument was passed into the venv creation method.

This change adds that argument to our call since it defaults to `True`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
