### PR TITLE
fix: Add pip back into venv for nightly SAM CLI

### DIFF
--- a/Formula/aws-sam-cli-nightly.rb
+++ b/Formula/aws-sam-cli-nightly.rb
@@ -38,7 +38,9 @@ class AwsSamCliNightly < Formula
     depends_on "python@3.8"
 
     def install
-      venv = virtualenv_create(libexec, "python3.8")
+      # https://github.com/aws/homebrew-tap/pull/504
+      # re-add pip to the virtualenv using without_pip=false
+      venv = virtualenv_create(libexec, "python3.8", without_pip:false)
       system libexec/"bin/pip", "install", "--upgrade", "pip"
       system libexec/"bin/pip", "install", "-v", "--ignore-installed", buildpath
       system libexec/"bin/pip", "uninstall", "-y", "aws-sam-cli"


### PR DESCRIPTION
*Issue #, if available:*
None.

*Description of changes:*
Add `pip` back into the venv for the nightly SAM CLI formula to confirm changes work outside of dev environment.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
