### PR TITLE
fix: add nightly formula back 

### DIFF
--- a/Formula/_aws-sam-cli-nightly.rb
+++ b/Formula/_aws-sam-cli-nightly.rb
@@ -1,0 +1,60 @@
+require_relative "../ConfigProvider/config_provider"
+
+class AwsSamCliNightly < Formula
+  include Language::Python::Virtualenv
+
+  config_provider = ConfigProvider.new("aws-sam-cli-nightly")
+
+  desc "AWS SAM CLI 🐿 is a tool for local development and testing of Serverless applications. This is a pre-release version of AWS SAM CLI"
+  homepage "https://github.com/aws/aws-sam-cli/"
+  url config_provider.url
+  sha256 config_provider.sha256
+  head "https://github.com/aws/aws-sam-cli.git", branch: "nightly-builds"
+
+  def self.is_native_binary_supported?
+    OS.linux? and Hardware::CPU.intel?
+  end
+
+  if AwsSamCliNightly.is_native_binary_supported?
+    # instructions for native installer
+    on_linux do
+      on_intel do
+        url config_provider.native_root_url + config_provider.native_linux_x86_file
+        sha256 config_provider.native_linux_x86_hash
+      end
+    end
+
+    def install
+      libexec.install Dir["dist/*"]
+      bin.write_exec_script libexec/"sam-nightly"
+    end
+  else
+    # instructions for python virtualenv installer
+    bottle do
+      root_url config_provider.root_url
+      sha256 cellar: :any_skip_relocation, sierra:       config_provider.sierra_hash
+    end
+
+    depends_on "python@3.8"
+
+    def install
+      # https://github.com/Homebrew/brew/pull/15792
+      # re-add pip to the virtualenv using without_pip=false
+      venv = virtualenv_create(libexec, "python3.8", without_pip:false)
+      system libexec/"bin/pip", "install", "--upgrade", "pip"
+      system libexec/"bin/pip", "install", "-v", "--ignore-installed", buildpath
+      system libexec/"bin/pip", "uninstall", "-y", "aws-sam-cli"
+      # bin folder is not created automatically
+      bin.mkpath
+      venv.pip_install_and_link buildpath
+    end
+  end  
+
+  test do
+    assert_match "Usage", shell_output("#{bin}/sam-nightly --help")
+    system bin/"sam-nightly --version"
+  end
+
+  opoo "On September 12, 2023, AWS will no longer maintain the Homebrew installer for nightly version of AWS SAM CLI (aws/tap/aws-sam-cli-nightly). 
+        For AWS supported installations, use the first-party installers (https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/manage-sam-cli-versions.html#manage-sam-cli-versions-nightly-build)."
+end

--- a/Formula/_aws-sam-cli.rb
+++ b/Formula/_aws-sam-cli.rb
@@ -1,0 +1,61 @@
+require_relative "../ConfigProvider/config_provider"
+
+class AwsSamCli < Formula
+  include Language::Python::Virtualenv
+
+  config_provider = ConfigProvider.new("aws-sam-cli")
+
+  desc "AWS SAM CLI 🐿 is a tool for local development and testing of Serverless applications"
+  homepage "https://github.com/awslabs/aws-sam-cli/"
+  url config_provider.url
+  sha256 config_provider.sha256
+  head "https://github.com/awslabs/aws-sam-cli.git", branch: "develop"
+
+  conflicts_with "aws-sam-cli-rc", because: "both install the 'sam' binary"
+
+  def self.is_native_binary_supported?
+    OS.linux? and Hardware::CPU.intel?
+  end
+
+  if AwsSamCli.is_native_binary_supported?
+    # instructions for native installer
+    on_linux do
+      on_intel do
+        url config_provider.native_root_url + config_provider.native_linux_x86_file
+        sha256 config_provider.native_linux_x86_hash
+      end
+    end
+
+    def install
+      libexec.install Dir["dist/*"]
+      bin.write_exec_script libexec/"sam"
+    end
+  else
+    # instructions for python virtualenv installer
+    bottle do
+      root_url config_provider.root_url
+      sha256 cellar: :any_skip_relocation, sierra:       config_provider.sierra_hash
+    end
+
+    depends_on "python@3.8"
+
+    def install
+      # https://github.com/Homebrew/brew/pull/15792
+      # re-add pip to the virtualenv using without_pip=false
+      venv = virtualenv_create(libexec, "python3.8", without_pip:false)
+      system libexec/"bin/pip", "install", "--upgrade", "pip"
+      system libexec/"bin/pip", "install", "-v", "--ignore-installed", buildpath
+      system libexec/"bin/pip", "uninstall", "-y", "aws-sam-cli"
+      venv.pip_install_and_link buildpath
+    end
+  end
+
+  test do
+    assert_match "Usage", shell_output("#{bin}/sam --help")
+    system bin/"sam --version"
+  end
+
+  opoo "On September 12, 2023, AWS will no longer maintain the Homebrew installer for AWS SAM CLI (aws/tap/aws-sam-cli). 
+        For AWS supported installations, use the first-party installers (https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/install-sam-cli.html). 
+        To continue using Homebrew, use the community supported installer (https://formulae.brew.sh/formula/aws-sam-cli)."
+end

--- a/appveyor-sam-cli-nightly.yml
+++ b/appveyor-sam-cli-nightly.yml
@@ -25,6 +25,8 @@ for:
 # Building bottles shell script.
 build_script:
   - ./build-formula.sh -f Formula/_aws-sam-cli-nightly.rb -b bottle-configs/aws-sam-cli-nightly.json
+  # since bottle is prefixed with '_', remove that extra '_' from final bottle filename
+  - for f in build/*.bottle.tar.gz; do mv -i -- "$f" "${f//_/}"; done
 
 artifacts:
   - path: "build/*.bottle.tar.gz"

--- a/appveyor-sam-cli-nightly.yml
+++ b/appveyor-sam-cli-nightly.yml
@@ -25,8 +25,20 @@ for:
 # Building bottles shell script.
 build_script:
   - ./build-formula.sh -f Formula/_aws-sam-cli-nightly.rb -b bottle-configs/aws-sam-cli-nightly.json
-  # since bottle is prefixed with '_', remove that extra '_' from final bottle filename
-  - cd build && for f in *.bottle.tar.gz; do mv -i -- "$f" "${f#*_}"; done
+  # since bottle is prefixed with '_', we need to run following steps to make it easy to use the bottle if needed
+  - cd build && for f in *.bottle.tar.gz; do mv -i -- "$f" "${f#*_}"; done # remove _ prefix from bottle name
+  - BOTTLE_FILE=(*.bottle.tar.gz)
+  # remove the underscore from folder inside tar.gz and re-pack it again
+  - mkdir tmp-bottle-folder 
+  - tar -xf $BOTTLE_FILE tmp-bottle-folder
+  - cd tmp-bottle-folder
+  - mv _aws-sam-cli-nightly/ aws-sam-cli-nightly/
+  - tar -czvf $BOTTLE_FILE aws-sam-cli-nightly/
+  # go to build folder again, replace original tar.gz file with the one which is updated, clean tmp folders
+  - cd ..
+  - rm $BOTTLE_FILE
+  - mv tmp-bottle-folder/$BOTTLE_FILE ./
+  - rm -rf tmp-bottle-folder
 
 artifacts:
   - path: "build/*.bottle.tar.gz"

--- a/appveyor-sam-cli-nightly.yml
+++ b/appveyor-sam-cli-nightly.yml
@@ -24,7 +24,7 @@ for:
 
 # Building bottles shell script.
 build_script:
-  - ./build-formula.sh -f Formula/_aws-sam-cli-nightly.rb -b bottle-configs/_aws-sam-cli-nightly.json
+  - ./build-formula.sh -f Formula/_aws-sam-cli-nightly.rb -b bottle-configs/aws-sam-cli-nightly.json
 
 artifacts:
   - path: "build/*.bottle.tar.gz"

--- a/appveyor-sam-cli-nightly.yml
+++ b/appveyor-sam-cli-nightly.yml
@@ -24,7 +24,7 @@ for:
 
 # Building bottles shell script.
 build_script:
-  - ./build-formula.sh -f Formula/_aws-sam-cli-nightly.rb
+  - ./build-formula.sh -f Formula/_aws-sam-cli-nightly.rb -b bottle-configs/_aws-sam-cli-nightly.json
 
 artifacts:
   - path: "build/*.bottle.tar.gz"

--- a/appveyor-sam-cli-nightly.yml
+++ b/appveyor-sam-cli-nightly.yml
@@ -26,7 +26,7 @@ for:
 build_script:
   - ./build-formula.sh -f Formula/_aws-sam-cli-nightly.rb -b bottle-configs/aws-sam-cli-nightly.json
   # since bottle is prefixed with '_', remove that extra '_' from final bottle filename
-  - for f in build/*.bottle.tar.gz; do mv -i -- "$f" "${f//_/}"; done
+  - cd build && for f in *.bottle.tar.gz; do mv -i -- "$f" "${f#*_}"; done
 
 artifacts:
   - path: "build/*.bottle.tar.gz"

--- a/appveyor-sam-cli-nightly.yml
+++ b/appveyor-sam-cli-nightly.yml
@@ -30,7 +30,7 @@ build_script:
   - BOTTLE_FILE=(*.bottle.tar.gz)
   # remove the underscore from folder inside tar.gz and re-pack it again
   - mkdir tmp-bottle-folder 
-  - tar -xf $BOTTLE_FILE tmp-bottle-folder
+  - tar -xf $BOTTLE_FILE -C tmp-bottle-folder
   - cd tmp-bottle-folder
   - mv _aws-sam-cli-nightly/ aws-sam-cli-nightly/
   - tar -czvf $BOTTLE_FILE aws-sam-cli-nightly/

--- a/appveyor-sam-cli-nightly.yml
+++ b/appveyor-sam-cli-nightly.yml
@@ -24,7 +24,7 @@ for:
 
 # Building bottles shell script.
 build_script:
-  - ./build-formula.sh -f Formula/aws-sam-cli-nightly.rb
+  - ./build-formula.sh -f Formula/_aws-sam-cli-nightly.rb
 
 artifacts:
   - path: "build/*.bottle.tar.gz"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,7 +26,21 @@ for:
 build_script:
   - brew tap aws/tap
   - sudo bash ./replace-local-tap.sh
-  - ./build-formula.sh -f Formula/aws-sam-cli.rb -u
+  - ./build-formula.sh -f Formula/_aws-sam-cli.rb -u -b bottle-configs/aws-sam-cli.json
+  # since bottle is prefixed with '_', we need to run following steps to make it easy to use the bottle if needed
+  - cd build && for f in *.bottle.tar.gz; do mv -i -- "$f" "${f#*_}"; done # remove _ prefix from bottle name
+  - BOTTLE_FILE=(*.bottle.tar.gz)
+  # remove the underscore from folder inside tar.gz and re-pack it again
+  - mkdir tmp-bottle-folder 
+  - tar -xf $BOTTLE_FILE -C tmp-bottle-folder
+  - cd tmp-bottle-folder
+  - mv _aws-sam-cli/ aws-sam-cli/
+  - tar -czvf $BOTTLE_FILE aws-sam-cli/
+  # go to build folder again, replace original tar.gz file with the one which is updated, clean tmp folders
+  - cd ..
+  - rm $BOTTLE_FILE
+  - mv tmp-bottle-folder/$BOTTLE_FILE ./
+  - rm -rf tmp-bottle-folder
 
 artifacts:
   - path: "build/*.bottle.tar.gz"

--- a/build-formula.sh
+++ b/build-formula.sh
@@ -36,6 +36,7 @@ USAGE=$(cat << 'EOM'
             -f          Formula file to build
 
           Optional:
+            -b          Override default bottle configuration file
             -h          Print this usage help
             -u          Use existing tap instead of untapping and retapping
             -l          Dynamically sets the TAP to the first git remote found that is not the official aws tap
@@ -55,6 +56,9 @@ while getopts "f:hult:" opt; do
   case ${opt} in
     f ) # Full Formula File Path
         FORMULA_FILE="${OPTARG}"
+      ;;
+    b ) # Override default bottle configuration path
+        BOTTLE_CONFIG="${OPTARG}"
       ;;
     l ) # Local fork
         LOCAL_FORK=1
@@ -139,7 +143,8 @@ brew uninstall -f ${BOTTLE}
 ## Build bottle
 brew install --build-bottle ${TAP}/${BOTTLE}
 
-BOTTLE_CONFIG=$(jq -r '.' ${SCRIPTPATH}/bottle-configs/${BOTTLE}.json)
+DEFAULT_BOTTLE_CONFIG=$(jq -r '.' ${SCRIPTPATH}/bottle-configs/${BOTTLE}.json)
+BOTTLE_CONFIG=${BOTTLE_CONFIG:-$DEFAULT_BOTTLE_CONFIG}
 BOTTLE_ASSET_VERSION="$(echo ${BOTTLE_CONFIG} | jq -r '.version')"
 echo "[${BOTTLE}]: Version -> ${BOTTLE_ASSET_VERSION}"
 BOTTLE_ASSET_URL="$(echo ${BOTTLE_CONFIG} | jq -r '.bottle.root_url')"

--- a/build-formula.sh
+++ b/build-formula.sh
@@ -52,7 +52,7 @@ USER_TAP=""
 TAP="${AWS_TAP}"
 
 # Process our input arguments
-while getopts "f:hult:" opt; do
+while getopts "f:b:hult:" opt; do
   case ${opt} in
     f ) # Full Formula File Path
         FORMULA_FILE="${OPTARG}"

--- a/build-formula.sh
+++ b/build-formula.sh
@@ -58,7 +58,7 @@ while getopts "f:b:hult:" opt; do
         FORMULA_FILE="${OPTARG}"
       ;;
     b ) # Override default bottle configuration path
-        BOTTLE_CONFIG="${OPTARG}"
+        BOTTLE_CONFIG_PATH="${SCRIPTPATH}/${OPTARG}"
       ;;
     l ) # Local fork
         LOCAL_FORK=1
@@ -143,8 +143,9 @@ brew uninstall -f ${BOTTLE}
 ## Build bottle
 brew install --build-bottle ${TAP}/${BOTTLE}
 
-DEFAULT_BOTTLE_CONFIG=$(jq -r '.' ${SCRIPTPATH}/bottle-configs/${BOTTLE}.json)
-BOTTLE_CONFIG=${BOTTLE_CONFIG:-$DEFAULT_BOTTLE_CONFIG}
+DEFAULT_BOTTLE_CONFIG_PATH="${SCRIPTPATH}/bottle-configs/${BOTTLE}.json"
+BOTTLE_CONFIG_PATH=${BOTTLE_CONFIG_PATH:-$DEFAULT_BOTTLE_CONFIG_PATH}
+BOTTLE_CONFIG=$(jq -r '.' ${BOTTLE_CONFIG_PATH})
 BOTTLE_ASSET_VERSION="$(echo ${BOTTLE_CONFIG} | jq -r '.version')"
 echo "[${BOTTLE}]: Version -> ${BOTTLE_ASSET_VERSION}"
 BOTTLE_ASSET_URL="$(echo ${BOTTLE_CONFIG} | jq -r '.bottle.root_url')"


### PR DESCRIPTION
*Issue #, if available:*
Adds temporary solutions to continue building brew bottles for aws-sam-cli until bottle publication jobs have been removed.

*Description of changes:*
- Adds nightly and production formula back with a leading underscore (without underscore, even though with `tap_migrations.json` file) it will still install from this tap, which is not something that we want.
- Adds `-b` option to `build-formula.sh` file to override configuration file during bottle creation (otherwise configuration file is also assumed to start with underscore by default).
- Updated Appveyor definitions with;
  - Included `-b` option to override default configuration setting due to formula file name change
  - Renames bottle file to remove leading underscore
  - Extracts, renames and re-packages `tar.gz` file to remove underscore from foldername inside bottle file


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
