### PR TITLE
 Update EMR on EKS custom image cli to v1.05

### DIFF
--- a/bottle-configs/amazon-emr-on-eks-custom-image-cli.json
+++ b/bottle-configs/amazon-emr-on-eks-custom-image-cli.json
@@ -1,13 +1,13 @@
 {
   "name": "amazon-emr-on-eks-custom-image-cli",
-  "version": "1.03",
+  "version": "1.05",
   "bin": "emr-on-eks-custom-image",
   "bottle": {
-    "root_url": "https://github.com/awslabs/amazon-emr-on-eks-custom-image-cli/releases/download/v1.03/amazon-emr-on-eks-custom-image-cli",
+    "root_url": "https://github.com/awslabs/amazon-emr-on-eks-custom-image-cli/releases/download/v1.05/amazon-emr-on-eks-custom-image-cli",
     "sha256": {
       "arm64_big_sur": "",
-      "sierra": "eb86ccb73d4cb18507c86aa2b45bed23476f59de03afd40396fa4b92f1b607af",
-      "linux": "e7df54e316337dc209e4d6fbf2a06e2f769e8c2e84a20b32b08c7c0d6d398ba6"
+      "sierra": "5168330a1801a901934eee52eb6695b958cfdd6044e0fdcf3d988b0ae0e6359a",
+      "linux": "c883ad7e7a0ac920037c06a8b83d419df7e4d85f7dee33c75637fbc1ef651c63"
     }
   }
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
 Updated the version to 1.02 for EMR on EKS custom image cli.
Last updated commit: https://github.com/aws/homebrew-tap/pull/314

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Tested locally with below command:
```
brew install --build-from-source Formula/emr-on-eks-custom-image.rb
```
and made it running successfully.
