### PR TITLE
Remove smithy-cli from tap_migrations.json

### DIFF
--- a/tap_migrations.json
+++ b/tap_migrations.json
@@ -1,4 +1,3 @@
 {
-  "smithy-cli": "smithy-lang/tap",
   "aws-sam-cli": "homebrew/core"
 }


### PR DESCRIPTION
*Description of changes:*
- When having both the aws and smithy-lang taps tapped, users will run into an issue where they have to fully qualify the brew command with smithy-lang/tap
```
❯ brew upgrade smithy-cli   
==> Downloading https://formulae.brew.sh/api/formula.jws.json

Warning: Formula aws/tap/smithy-cli was renamed to smithy-lang/tap/smithy-cli.
Error: Formulae found in multiple taps:
       * smithy-lang/tap/smithy-cli
       * smithy-lang/tap/smithy-cli

Please use the fully-qualified name (e.g. smithy-lang/tap/smithy-cli) to refer to a specific formula.
```

- Removing this entry means this problem will go away
- I did not remove the README entry about the formula being migrated, since it is still valid
- Note: even untapping smithy-lang and keeping aws still renders the error - I'm not sure if this is a bug in how brew handles migrations (but it does not happen for formula migrated to homebrew/core

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
