### PR TITLE
cbmc-viewer: Address `brew audit` error

### DIFF
--- a/Formula/cbmc-viewer.rb
+++ b/Formula/cbmc-viewer.rb
@@ -59,6 +59,6 @@ class CbmcViewer < Formula
                               "--coverage", "coverage.xml",
                               "--property", "property.xml",
                               "--srcdir", "."
-    assert_predicate testpath/"report/html/index.html", :exist?
+    assert_path_exists testpath/"report/html/index.html"
   end
 end


### PR DESCRIPTION
*Description of changes:*

Addresses the following error:
```
Error: 1 problem in 1 formula detected.
  * line 62, col 5: Use `assert_path_exists <path_to_file>` instead of `assert_predicate testpath/"report/html/index.html", :exist?`
Error: `brew audit` failed for cbmc-viewer!
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
