### PR TITLE
Revert "cbmc-viewer"

### DIFF
--- a/Formula/cbmc-viewer.rb
+++ b/Formula/cbmc-viewer.rb
@@ -3,8 +3,8 @@ class CbmcViewer < Formula
   desc "Scans the output of CBMC and produces a browsable summary of the results"
   homepage "https://github.com/model-checking/cbmc-viewer"
   url "https://github.com/model-checking/cbmc-viewer.git",
-      tag:      "viewer-3.11",
-      revision: "324ed4d2af508ce7bb0e04d9aaf485be27e0a542"
+      tag:      "viewer-3.10",
+      revision: "234256dbe50d86b0f31640d109e998a3e3fe8d4f"
   license "Apache-2.0"
 
   bottle do


### PR DESCRIPTION
*Description of changes:*

This reverts commit 1b2a38f6abd4b23ce2cbed1e1239025b80e457d5, which introduced an incomplete update (the bottles still point to viewer-3.10).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
