### PR TITLE
cbmc-viewer: add blank line as required by brew audit

### DIFF
--- a/Formula/cbmc-viewer.rb
+++ b/Formula/cbmc-viewer.rb
@@ -1,5 +1,6 @@
 class CbmcViewer < Formula
   include Language::Python::Virtualenv
+
   desc "Scans the output of CBMC and produces a browsable summary of the results"
   homepage "https://github.com/model-checking/cbmc-viewer"
   url "https://github.com/model-checking/cbmc-viewer.git",


### PR DESCRIPTION
*Description of changes:*

This addresses the following (new) error:
```
aws/tap/cbmc-viewer
  * line 2, col 3: Add an empty line after module inclusion.
Error: 1 problem in 1 formula detected.
Error: `brew audit` failed for cbmc-viewer!
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
