### PR TITLE
Update lightsailctl to v1.0.8

### DIFF
--- a/bottle-configs/lightsailctl.json
+++ b/bottle-configs/lightsailctl.json
@@ -1,7 +1,7 @@
 {
-    "version": "1.0.7",
-    "url": "https://github.com/aws/lightsailctl/archive/v1.0.7.tar.gz",
-    "sha256": "b01945c7a47a2fee3c6545f3536c6ba7b62ba3afc6842c41d514237936ba891f",
+    "version": "1.0.8",
+    "url": "https://github.com/aws/lightsailctl/archive/v1.0.8.tar.gz",
+    "sha256": "c9f1e45a15a5e8f3d7634f1bbd4a26d289ea421df27459001fb84b494d5ad10c",
     "name": "lightsailctl",
     "bin": "lightsailctl"
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Updating the version of lightsailctl to 1.0.8. You can verify the SHA-256 with the following command:

`curl -sL "https://github.com/aws/lightsailctl/archive/refs/tags/v1.0.8.tar.gz" | sha256sum`

[Link](https://github.com/aws/homebrew-tap/commit/4c7ececd1012abf591b5d7e0d6fcf406093298f4) to previous PR.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
